### PR TITLE
feat(clone): make url interactive

### DIFF
--- a/docs/dargstack_clone.md
+++ b/docs/dargstack_clone.md
@@ -7,16 +7,20 @@ Clone an existing dargstack project
 Clone an existing dargstack project from a Git URL.
 
 Supports https://, git@, git://, and ssh:// URLs.
-The repository is cloned into the current directory.
+Without arguments, prompts for a Git URL.
+By default, clones into a subdirectory of the current directory named after the repository.
+
+Use --target to specify a different directory for the clone.
 
 ```
-dargstack clone <url> [flags]
+dargstack clone [url] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for clone
+  -h, --help            help for clone
+      --target string   target directory for the clone (default: inferred from URL)
 ```
 
 ### Options inherited from parent commands

--- a/docs/dargstack_initialize.md
+++ b/docs/dargstack_initialize.md
@@ -15,6 +15,7 @@ Without arguments, prompts for a project name.
 With an argument, uses it as the project name directly.
 
 Use `--configuration-only` to print a full config template to stdout without creating a project.
+Use `--target` to specify the parent directory for the project (default: current directory).
 
 DEPRECATED: passing a Git URL to `init` will clone the repository.
 Use `dargstack clone` instead.
@@ -28,6 +29,7 @@ dargstack initialize [name] [flags]
 ```
       --configuration-only   print config template to stdout without creating a project
   -h, --help                 help for initialize
+      --target string        parent directory for the project (default: current directory)
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -4,37 +4,85 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	"github.com/dargstack/dargstack/v4/internal/giturl"
 	"github.com/dargstack/dargstack/v4/internal/logger"
+	"github.com/dargstack/dargstack/v4/internal/prompt"
 )
 
+var cloneTarget string
+
 var cloneCmd = &cobra.Command{
-	Use:   "clone <url>",
+	Use:   "clone [url]",
 	Short: "Clone an existing dargstack project",
 	Long: `Clone an existing dargstack project from a Git URL.
 
 Supports https://, git@, git://, and ssh:// URLs.
-The repository is cloned into the current directory.`,
-	Args: cobra.ExactArgs(1),
+Without arguments, prompts for a Git URL.
+By default, clones into a subdirectory of the current directory named after the repository.
+
+Use --target to specify a different directory for the clone.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runClone,
 }
 
+func init() {
+	cloneCmd.Flags().StringVar(&cloneTarget, "target", "", "target directory for the clone (default: inferred from URL)")
+}
+
 func runClone(cmd *cobra.Command, args []string) error {
-	url := args[0]
+	url := ""
+	if len(args) > 0 {
+		url = args[0]
+	}
+
+	if url == "" {
+		if noInteraction {
+			return fmt.Errorf("--no-interaction requires a url argument")
+		}
+
+		var err error
+		url, err = prompt.Input("Git URL", "")
+		if err != nil {
+			return err
+		}
+	}
+
+	if url == "" {
+		return fmt.Errorf("git URL is required")
+	}
 
 	if !isGitURL(url) {
 		return fmt.Errorf("%q does not appear to be a Git URL", url)
 	}
 
-	logger.L.Info(fmt.Sprintf("Cloning %s ...", url))
-	gitCmd := exec.Command("git", "clone", url) // #nosec G204 — URL is user-supplied intentionally
+	target := cloneTarget
+	if target == "" {
+		target = giturl.RepoNameFromURL(url)
+	}
+
+	if !noInteraction {
+		result, err := prompt.Input("Clone into directory", target)
+		if err != nil {
+			return err
+		}
+		target = result
+	}
+
+	if target == "" {
+		return fmt.Errorf("target directory is required")
+	}
+
+	logger.L.Info(fmt.Sprintf("Cloning %s into ./%s ...", url, target))
+	gitCmd := exec.Command("git", "clone", url, target) // #nosec G204 — URL is user-supplied intentionally
 	gitCmd.Stdout = os.Stdout
 	gitCmd.Stderr = os.Stderr
 	if err := gitCmd.Run(); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
-	logger.Success("Project cloned. Navigate into the directory and run `dargstack deploy`.")
+	logger.Success(fmt.Sprintf("Project cloned into ./%s. Navigate into the directory and run `dargstack deploy`.", filepath.Base(target)))
 	return nil
 }

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -60,11 +60,12 @@ func runClone(cmd *cobra.Command, args []string) error {
 	}
 
 	target := cloneTarget
-	if target == "" {
+	targetExplicit := cmd.Flags().Changed("target")
+	if !targetExplicit {
 		target = giturl.RepoNameFromURL(url)
 	}
 
-	if !noInteraction {
+	if !targetExplicit && !noInteraction {
 		result, err := prompt.Input("Clone into directory", target)
 		if err != nil {
 			return err
@@ -76,13 +77,19 @@ func runClone(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("target directory is required")
 	}
 
-	logger.L.Info(fmt.Sprintf("Cloning %s into ./%s ...", url, target))
+	displayTarget := target
+	if !filepath.IsAbs(target) {
+		displayTarget = "./" + target
+	}
+
+	logger.L.Info(fmt.Sprintf("Cloning %s into %s ...", url, displayTarget))
 	gitCmd := exec.Command("git", "clone", url, target) // #nosec G204 — URL is user-supplied intentionally
 	gitCmd.Stdout = os.Stdout
 	gitCmd.Stderr = os.Stderr
 	if err := gitCmd.Run(); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
-	logger.Success(fmt.Sprintf("Project cloned into ./%s. Navigate into the directory and run `dargstack deploy`.", filepath.Base(target)))
+	logger.Success(fmt.Sprintf("Project cloned into %s", displayTarget))
+	logger.L.Info("Run `cd` into the directory and then `dargstack deploy` to start.")
 	return nil
 }

--- a/internal/cli/initialize.go
+++ b/internal/cli/initialize.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dargstack/dargstack/v4/internal/giturl"
 	"github.com/dargstack/dargstack/v4/internal/logger"
 	"github.com/dargstack/dargstack/v4/internal/prompt"
 )
 
 var configOnly bool
+var initTarget string
 
 var initCmd = &cobra.Command{
 	Use:     "initialize [name]",
@@ -30,6 +32,7 @@ Without arguments, prompts for a project name.
 With an argument, uses it as the project name directly.
 
 Use ` + "`--configuration-only`" + ` to print a full config template to stdout without creating a project.
+Use ` + "`--target`" + ` to specify the parent directory for the project (default: current directory).
 
 DEPRECATED: passing a Git URL to ` + "`init`" + ` will clone the repository.
 Use ` + "`dargstack clone`" + ` instead.`,
@@ -39,6 +42,7 @@ Use ` + "`dargstack clone`" + ` instead.`,
 
 func init() {
 	initCmd.Flags().BoolVar(&configOnly, "configuration-only", false, "print config template to stdout without creating a project")
+	initCmd.Flags().StringVar(&initTarget, "target", "", "parent directory for the project (default: current directory)")
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -68,12 +72,40 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("project name is required")
 	}
 
-	if isGitURL(name) {
+	isClone := isGitURL(name)
+	if isClone {
 		logger.L.Warn("Passing a Git URL to `init` is deprecated; use `dargstack clone` instead.")
-		return cloneProject(name)
 	}
 
-	return bootstrapProject(name)
+	target := initTarget
+	if target == "" {
+		if isClone {
+			target = giturl.RepoNameFromURL(name)
+		} else {
+			target = "."
+		}
+	}
+
+	if !noInteraction {
+		promptTitle := "Clone into directory"
+		if !isClone {
+			promptTitle = "Create project in directory"
+		}
+		result, err := prompt.Input(promptTitle, target)
+		if err != nil {
+			return err
+		}
+		target = result
+	}
+
+	if target == "" {
+		return fmt.Errorf("target directory is required")
+	}
+
+	if isClone {
+		return cloneProject(name, target)
+	}
+	return bootstrapProject(name, target)
 }
 
 func isGitURL(s string) bool {
@@ -84,25 +116,26 @@ func isGitURL(s string) bool {
 		strings.HasPrefix(s, "ssh://")
 }
 
-func cloneProject(url string) error {
-	logger.L.Info(fmt.Sprintf("Cloning %s ...", url))
-	gitCmd := exec.Command("git", "clone", url) // #nosec G204 — URL is user-supplied intentionally
+func cloneProject(url, target string) error {
+	logger.L.Info(fmt.Sprintf("Cloning %s into ./%s ...", url, target))
+	gitCmd := exec.Command("git", "clone", url, target) // #nosec G204 — URL is user-supplied intentionally
 	gitCmd.Stdout = os.Stdout
 	gitCmd.Stderr = os.Stderr
 	if err := gitCmd.Run(); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
-	logger.Success("Project cloned. Navigate into the directory and run `dargstack deploy`.")
+	logger.Success(fmt.Sprintf("Project cloned into ./%s. Navigate into the directory and run `dargstack deploy`.", filepath.Base(target)))
 	return nil
 }
 
-func bootstrapProject(name string) error {
-	stackDir := filepath.Join(name, "stack")
-	helloDir := filepath.Join(name, "hello")
+func bootstrapProject(name, target string) error {
+	projectDir := filepath.Join(target, name)
+	stackDir := filepath.Join(projectDir, "stack")
+	helloDir := filepath.Join(projectDir, "hello")
 
-	if _, err := os.Stat(name); err == nil {
+	if _, err := os.Stat(projectDir); err == nil {
 		return hintErr(
-			fmt.Errorf("directory %q already exists", name),
+			fmt.Errorf("directory %q already exists", projectDir),
 			"Choose a different name, or remove the existing directory first.",
 		)
 	}
@@ -181,11 +214,11 @@ func bootstrapProject(name string) error {
 
 	// Write project-level README as a sibling to the stack directory
 	projectReadme := fmt.Sprintf(initReadmeProject, name, name)
-	if err := os.WriteFile(filepath.Join(name, "README.md"), []byte(projectReadme), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(projectDir, "README.md"), []byte(projectReadme), 0o644); err != nil {
 		return fmt.Errorf("write project README.md: %w", err)
 	}
 
-	logger.Success(fmt.Sprintf("Project %q bootstrapped at ./%s", name, stackDir))
+	logger.Success(fmt.Sprintf("Project %q bootstrapped at %s", name, stackDir))
 	logger.L.Info(fmt.Sprintf("Next steps:\n  cd %s\n  dargstack deploy", stackDir))
 	return nil
 }

--- a/internal/cli/initialize.go
+++ b/internal/cli/initialize.go
@@ -78,7 +78,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	target := initTarget
-	if target == "" {
+	targetExplicit := cmd.Flags().Changed("target")
+	if !targetExplicit {
 		if isClone {
 			target = giturl.RepoNameFromURL(name)
 		} else {
@@ -86,7 +87,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if !noInteraction {
+	if !targetExplicit && !noInteraction {
 		promptTitle := "Clone into directory"
 		if !isClone {
 			promptTitle = "Create project in directory"
@@ -117,14 +118,20 @@ func isGitURL(s string) bool {
 }
 
 func cloneProject(url, target string) error {
-	logger.L.Info(fmt.Sprintf("Cloning %s into ./%s ...", url, target))
+	displayTarget := target
+	if !filepath.IsAbs(target) {
+		displayTarget = "./" + target
+	}
+
+	logger.L.Info(fmt.Sprintf("Cloning %s into %s ...", url, displayTarget))
 	gitCmd := exec.Command("git", "clone", url, target) // #nosec G204 — URL is user-supplied intentionally
 	gitCmd.Stdout = os.Stdout
 	gitCmd.Stderr = os.Stderr
 	if err := gitCmd.Run(); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
-	logger.Success(fmt.Sprintf("Project cloned into ./%s. Navigate into the directory and run `dargstack deploy`.", filepath.Base(target)))
+	logger.Success(fmt.Sprintf("Project cloned into %s", displayTarget))
+	logger.L.Info("Run `cd` into the directory and then `dargstack deploy` to start.")
 	return nil
 }
 


### PR DESCRIPTION
This pull request enhances the `clone` and `initialize` CLI commands by introducing a `--target` flag to control the destination directory, improving user prompts, and unifying the handling of target directories for both cloning and project initialization. It also updates help text and internal logic for greater clarity and flexibility.
