### PR TITLE
fix(git): account for os when resolving ssh agent

### DIFF
--- a/internal/giturl/giturl.go
+++ b/internal/giturl/giturl.go
@@ -2,10 +2,7 @@ package giturl
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/dargstack/dargstack/v4/internal/logger"
 )
@@ -50,29 +47,6 @@ func RepoNameFromURL(url string) string {
 	}
 	name = strings.TrimSuffix(name, ".git")
 	return name
-}
-
-// SSHAgentAvailable returns true if an SSH agent is running and accessible.
-func SSHAgentAvailable() bool {
-	sock := os.Getenv("SSH_AUTH_SOCK")
-	if sock == "" {
-		return false
-	}
-
-	info, err := os.Stat(sock)
-	if err != nil {
-		return false
-	}
-	if info.Mode()&os.ModeSocket == 0 {
-		return false
-	}
-
-	cmd := exec.Command("ssh-add", "-l")
-	cmd.Env = append(os.Environ(), "SSH_AUTH_SOCK="+sock)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
-	return cmd.Run() == nil
 }
 
 const (

--- a/internal/giturl/giturl_test.go
+++ b/internal/giturl/giturl_test.go
@@ -86,13 +86,6 @@ func TestRepoNameFromURL(t *testing.T) {
 	}
 }
 
-func TestSSHAgentAvailable_NoEnvVar(t *testing.T) {
-	t.Setenv("SSH_AUTH_SOCK", "")
-	if SSHAgentAvailable() {
-		t.Error("SSHAgentAvailable() should be false when SSH_AUTH_SOCK is not set")
-	}
-}
-
 func TestExtractFromService(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/giturl/giturl_unix.go
+++ b/internal/giturl/giturl_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package giturl
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// SSHAgentAvailable returns true if an SSH agent is running and accessible.
+func SSHAgentAvailable() bool {
+	sock := os.Getenv("SSH_AUTH_SOCK")
+	if sock == "" {
+		return false
+	}
+
+	info, err := os.Stat(sock)
+	if err != nil {
+		return false
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return false
+	}
+
+	cmd := exec.Command("ssh-add", "-l")
+	cmd.Env = append(os.Environ(), "SSH_AUTH_SOCK="+sock)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+	return cmd.Run() == nil
+}

--- a/internal/giturl/giturl_unix_test.go
+++ b/internal/giturl/giturl_unix_test.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package giturl
+
+import "testing"
+
+func TestSSHAgentAvailable_NoEnvVar(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+	if SSHAgentAvailable() {
+		t.Error("SSHAgentAvailable() should be false when SSH_AUTH_SOCK is not set")
+	}
+}

--- a/internal/giturl/giturl_windows.go
+++ b/internal/giturl/giturl_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package giturl
+
+// SSHAgentAvailable always returns false on Windows as SSH_AUTH_SOCK
+// unix socket mechanism is not available.
+func SSHAgentAvailable() bool {
+	return false
+}


### PR DESCRIPTION
This pull request refactors the implementation of the `SSHAgentAvailable` function to provide platform-specific versions for Unix-like and Windows systems. The main logic for detecting an SSH agent is now only included for Unix platforms, and a stub is provided for Windows where the mechanism is not supported. Related tests have also been moved to corresponding platform-specific test files.