### PR TITLE
feat(deploy): inform about up-to-date repositories

### DIFF
--- a/internal/cli/deploy_image.go
+++ b/internal/cli/deploy_image.go
@@ -261,6 +261,10 @@ func fetchAndWarnBehind(composeData []byte) []gitBehindInfo {
 		}).
 		Run()
 
+	if len(behind) == 0 && len(dirs) > 0 {
+		logger.Success("All repositories are up to date")
+		return nil
+	}
 	if len(behind) == 0 {
 		return nil
 	}

--- a/internal/cli/deploy_run.go
+++ b/internal/cli/deploy_run.go
@@ -528,6 +528,7 @@ func cloneGitRepos(stackDir string, composeData []byte) ([]byte, error) {
 
 				makefile := filepath.Join(targetDir, "Makefile")
 				if _, statErr := os.Stat(makefile); statErr == nil {
+					logger.L.Warn(fmt.Sprintf("service %q: running `make init` on cloned repositories is deprecated and will be removed in a future version", name))
 					logger.L.Info(fmt.Sprintf("Initializing %s for service %q", repoName, name))
 					initCmd := exec.Command("make", "init")
 					initCmd.Dir = targetDir

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -211,7 +211,11 @@ func generateWithMkcert(certDir string, domains []string) error {
 		return fmt.Errorf("mkcert: %w", err)
 	}
 
-	logger.Success(fmt.Sprintf("TLS certificate generated for %d domain(s)", len(domains)))
+	plural := ""
+	if len(domains) != 1 {
+		plural = "s"
+	}
+	logger.Success(fmt.Sprintf("TLS certificate generated for %d domain%s", len(domains), plural))
 	return nil
 }
 


### PR DESCRIPTION
This pull request introduces several user experience improvements and minor deprecation warnings to the CLI tools. The main changes focus on providing clearer feedback to users during deployment and certificate generation, and warning about deprecated behaviors.

User experience improvements:

* In `deploy_image.go`, added a success message ("All repositories are up to date") when no repositories are behind, making the status clearer to users.
* In `tls.go`, improved the TLS certificate generation message to correctly pluralize "domain" based on the number of domains, enhancing message clarity.

Deprecation warnings:

* In `deploy_run.go`, added a warning log when `make init` is run on cloned repositories, informing users that this behavior is deprecated and will be removed in a future version.