### PR TITLE
feat(cli): support `COMPOSE_PROFILES` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ services:
 
 Multiple profiles: `dargstack.profiles: "db,monitoring"` (comma-separated).
 
+Profiles can also be activated via the `COMPOSE_PROFILES` environment variable (comma-separated). The `--profiles` flag takes precedence over `COMPOSE_PROFILES`.
+
 If no profile selection is made and any service declares `default`, only services with `dargstack.profiles: default` are deployed; unlabeled services are excluded.
 If no profile selection is made and no service declares `default`, all services (including unlabeled) are deployed.
 

--- a/docs/dargstack.md
+++ b/docs/dargstack.md
@@ -17,7 +17,7 @@ dargstack - simplified, approachable Docker Swarm stack management.
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_audit.md
+++ b/docs/dargstack_audit.md
@@ -30,7 +30,7 @@ dargstack audit [timestamp] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_build.md
+++ b/docs/dargstack_build.md
@@ -35,7 +35,7 @@ dargstack build [service...] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_certify.md
+++ b/docs/dargstack_certify.md
@@ -29,7 +29,7 @@ dargstack certify [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_clone.md
+++ b/docs/dargstack_clone.md
@@ -33,7 +33,7 @@ dargstack clone [url] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_deploy.md
+++ b/docs/dargstack_deploy.md
@@ -40,7 +40,7 @@ dargstack deploy [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_document.md
+++ b/docs/dargstack_document.md
@@ -30,7 +30,7 @@ dargstack document [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_initialize.md
+++ b/docs/dargstack_initialize.md
@@ -42,7 +42,7 @@ dargstack initialize [name] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_profiles.md
+++ b/docs/dargstack_profiles.md
@@ -29,7 +29,7 @@ dargstack profiles [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_remove.md
+++ b/docs/dargstack_remove.md
@@ -33,7 +33,7 @@ dargstack remove [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_secret.md
+++ b/docs/dargstack_secret.md
@@ -29,7 +29,7 @@ Use 'dargstack secret status' to check which secrets are set, missing, or hold p
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_secret_generate.md
+++ b/docs/dargstack_secret_generate.md
@@ -37,7 +37,7 @@ dargstack secret generate [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_secret_show.md
+++ b/docs/dargstack_secret_show.md
@@ -36,7 +36,7 @@ dargstack secret show [name] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_secret_status.md
+++ b/docs/dargstack_secret_status.md
@@ -31,7 +31,7 @@ dargstack secret status [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_update.md
+++ b/docs/dargstack_update.md
@@ -27,7 +27,7 @@ dargstack update [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/docs/dargstack_validate.md
+++ b/docs/dargstack_validate.md
@@ -31,7 +31,7 @@ dargstack validate [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
-  -p, --profiles strings       activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined
+  -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output
 ```

--- a/internal/cli/messages.go
+++ b/internal/cli/messages.go
@@ -20,7 +20,7 @@ const (
 	TipAddSecretMetadata   = "Tip: Add x-dargstack.secrets entries with typed secret metadata to auto-generate missing secrets."
 
 	// Flag descriptions
-	FlagDescProfiles = "activate one or more compose profiles; unlabeled services are included unless a 'default' profile is defined"
+	FlagDescProfiles = "activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined"
 
 	// Prompt choices
 	ChoiceAutoGenAll  = "Auto-generate this and remaining auto-generatable secrets"

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -44,6 +45,8 @@ var rootCmd = &cobra.Command{
 	Version:      fmt.Sprintf("%s (commit: %s, built: %s)", version.Version, version.Commit, version.Date),
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		resolveProfiles()
+
 		// Propagate --no-interaction to the prompt package.
 		prompt.NonInteractive = noInteraction
 
@@ -164,6 +167,22 @@ func isSkippedCommand(cmd *cobra.Command) bool {
 
 // isProduction returns true if the active --environment is "production".
 func isProduction() bool { return env == "production" }
+
+// resolveProfiles reads COMPOSE_PROFILES env var and populates the profiles
+// variable when the --profiles flag was not used.
+func resolveProfiles() {
+	if profiles != nil {
+		return
+	}
+	if raw := os.Getenv("COMPOSE_PROFILES"); raw != "" {
+		for _, p := range strings.Split(raw, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				profiles = append(profiles, p)
+			}
+		}
+	}
+}
 
 // wrapWithBugHint wraps an error with a hint to report bugs or ask for help.
 func wrapWithBugHint(err error) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/dargstack/dargstack/v4/internal/logger"
@@ -62,6 +63,83 @@ func TestLoggerRespectsLogLevel(t *testing.T) {
 			}
 			if gotStderr != tt.expectStderr {
 				t.Errorf("stderr: got %v, want %v (buf: %q)", gotStderr, tt.expectStderr, errBuf.String())
+			}
+		})
+	}
+}
+
+func TestResolveProfiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVar     string
+		flagSet    bool
+		flagValue  []string
+		wantNil    bool
+		wantValues []string
+	}{
+		{
+			name:       "env var populates profiles when flag not set",
+			envVar:     "db,monitoring",
+			flagSet:    false,
+			wantNil:    false,
+			wantValues: []string{"db", "monitoring"},
+		},
+		{
+			name:       "flag overrides env var",
+			envVar:     "db,monitoring",
+			flagSet:    true,
+			flagValue:  []string{"foo"},
+			wantNil:    false,
+			wantValues: []string{"foo"},
+		},
+		{
+			name:       "whitespace and empty entries are trimmed",
+			envVar:     " db , ,monitoring ",
+			flagSet:    false,
+			wantNil:    false,
+			wantValues: []string{"db", "monitoring"},
+		},
+		{
+			name:    "empty env var leaves profiles nil",
+			envVar:  "",
+			flagSet: false,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldProfiles := profiles
+			defer func() { profiles = oldProfiles }()
+
+			if tt.envVar != "" {
+				t.Setenv("COMPOSE_PROFILES", tt.envVar)
+			} else {
+				t.Setenv("COMPOSE_PROFILES", "")
+			}
+
+			profiles = nil
+			if tt.flagSet {
+				profiles = tt.flagValue
+			}
+
+			resolveProfiles()
+
+			if tt.wantNil {
+				if profiles != nil {
+					t.Errorf("expected profiles to be nil, got %v", profiles)
+				}
+				return
+			}
+
+			if profiles == nil {
+				t.Fatal("expected profiles to be non-nil")
+			}
+
+			got := strings.Join(profiles, ",")
+			want := strings.Join(tt.wantValues, ",")
+			if got != want {
+				t.Errorf("profiles: got %q, want %q", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request adds support for activating Docker Compose profiles via the `COMPOSE_PROFILES` environment variable, in addition to the existing `--profiles` flag. It ensures that the flag takes precedence over the environment variable and updates documentation and help messages accordingly.