### PR TITLE
feat(deploy): add platform override

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Contributing? See [CONTRIBUTING.md](CONTRIBUTING.md).
   - [Profiles & Performance](#profiles--performance)
   - [Secret Templating](#secret-templating)
   - [Environment Files](#environment-files)
+  - [Platform Overrides](#platform-overrides)
 - [Commands](#commands)
 
 ---
@@ -331,6 +332,43 @@ x-dargstack:
 ### Environment Files
 
 `.env` files use `KEY=VALUE` format. During deploy, missing values are prompted. Production blocks on missing values.
+
+### Platform Overrides
+
+dargstack is linux-first. When running on macOS, some compose configurations are invalid or undesirable: volume mounts referencing Linux-only paths (`/dev/disk/by-id/`, `/dev/kmsg`), `privileged: true` where not needed, or services like `cadvisor` that depend on Linux kernel features.
+
+Platform overrides live under `x-dargstack.platform.<os>` and use spruce operators to modify the base configuration. Supported platforms: `darwin`, `linux`, `windows`.
+
+```yaml
+services:
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.50.0
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/by-id/:/dev/disk/by-id:ro
+    devices:
+      - /dev/kmsg
+    privileged: true
+
+x-dargstack:
+  platform:
+    darwin:
+      services:
+        cadvisor:
+          volumes:
+            - (( prune ))
+            - /:/rootfs:ro
+            - /var/run:/var/run:ro
+            - /sys:/sys:ro
+          devices:
+            - (( prune ))
+          privileged: false
+```
+
+Multiple platforms can coexist in one file. The active platform is auto-detected via `runtime.GOOS`, or overridden with `--platform darwin`.
 
 ## Commands
 

--- a/docs/dargstack.md
+++ b/docs/dargstack.md
@@ -17,6 +17,7 @@ dargstack - simplified, approachable Docker Swarm stack management.
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_audit.md
+++ b/docs/dargstack_audit.md
@@ -30,6 +30,7 @@ dargstack audit [timestamp] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_build.md
+++ b/docs/dargstack_build.md
@@ -35,6 +35,7 @@ dargstack build [service...] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_certify.md
+++ b/docs/dargstack_certify.md
@@ -29,6 +29,7 @@ dargstack certify [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_clone.md
+++ b/docs/dargstack_clone.md
@@ -33,6 +33,7 @@ dargstack clone [url] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_deploy.md
+++ b/docs/dargstack_deploy.md
@@ -40,6 +40,7 @@ dargstack deploy [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_document.md
+++ b/docs/dargstack_document.md
@@ -30,6 +30,7 @@ dargstack document [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_initialize.md
+++ b/docs/dargstack_initialize.md
@@ -42,6 +42,7 @@ dargstack initialize [name] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_profiles.md
+++ b/docs/dargstack_profiles.md
@@ -29,6 +29,7 @@ dargstack profiles [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_remove.md
+++ b/docs/dargstack_remove.md
@@ -33,6 +33,7 @@ dargstack remove [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_secret.md
+++ b/docs/dargstack_secret.md
@@ -29,6 +29,7 @@ Use 'dargstack secret status' to check which secrets are set, missing, or hold p
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_secret_generate.md
+++ b/docs/dargstack_secret_generate.md
@@ -37,6 +37,7 @@ dargstack secret generate [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_secret_show.md
+++ b/docs/dargstack_secret_show.md
@@ -36,6 +36,7 @@ dargstack secret show [name] [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_secret_status.md
+++ b/docs/dargstack_secret_status.md
@@ -31,6 +31,7 @@ dargstack secret status [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_update.md
+++ b/docs/dargstack_update.md
@@ -27,6 +27,7 @@ dargstack update [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/docs/dargstack_validate.md
+++ b/docs/dargstack_validate.md
@@ -31,6 +31,7 @@ dargstack validate [flags]
   -l, --log-level string       log level: error, warn, info, debug (default "info")
   -n, --no-interaction         disable interactive prompts
   -o, --offline                skip fetching remote resources
+      --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
   -s, --services strings       filter to specific services
   -v, --verbose                verbose output

--- a/internal/cli/deploy_compose.go
+++ b/internal/cli/deploy_compose.go
@@ -32,9 +32,9 @@ func buildDevelopmentCompose() ([]byte, error) {
 
 	var data []byte
 	if len(paths) == 1 {
-		data, err = compose.LoadSingle(stackDir, paths[0])
+		data, err = compose.LoadSingle(stackDir, getPlatform(), paths[0])
 	} else {
-		data, err = compose.MergeFiles(stackDir, paths...)
+		data, err = compose.MergeFiles(stackDir, getPlatform(), paths...)
 	}
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ func buildProductionCompose() ([]byte, error) {
 
 	// MergeFilesProduction strips # dargstack:dev-only markers from each source
 	// file's raw bytes before YAML parsing, since YAML roundtrips discard comments.
-	merged, err := compose.MergeFilesProduction(stackDir, paths...)
+	merged, err := compose.MergeFilesProduction(stackDir, getPlatform(), paths...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dargstack/dargstack/v4/internal/config"
 	"github.com/dargstack/dargstack/v4/internal/logger"
+	"github.com/dargstack/dargstack/v4/internal/platform"
 	"github.com/dargstack/dargstack/v4/internal/prompt"
 	"github.com/dargstack/dargstack/v4/internal/update"
 	"github.com/dargstack/dargstack/v4/internal/version"
@@ -23,6 +24,7 @@ var (
 	noInteraction bool
 	offline       bool
 	outputFormat  string
+	platformFlag  string
 	profiles      []string
 	services      []string
 	verbose       bool
@@ -122,6 +124,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "format", "f", "table", "output format for compatible commands: table|json")
 	rootCmd.PersistentFlags().BoolVarP(&noInteraction, "no-interaction", "n", false, "disable interactive prompts")
 	rootCmd.PersistentFlags().BoolVarP(&offline, "offline", "o", false, "skip fetching remote resources")
+	rootCmd.PersistentFlags().StringVar(&platformFlag, "platform", "", "target platform for compose overrides (default: auto-detect)")
 	rootCmd.PersistentFlags().StringSliceVarP(&profiles, "profiles", "p", nil, FlagDescProfiles)
 	rootCmd.PersistentFlags().StringSliceVarP(&services, "services", "s", nil, "filter to specific services")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
@@ -167,6 +170,12 @@ func isSkippedCommand(cmd *cobra.Command) bool {
 
 // isProduction returns true if the active --environment is "production".
 func isProduction() bool { return env == "production" }
+
+// getPlatform returns the target platform for compose overrides.
+// Uses --platform flag if set, otherwise auto-detects via runtime.GOOS.
+func getPlatform() string {
+	return platform.Get(platformFlag)
+}
 
 // resolveProfiles reads COMPOSE_PROFILES env var and populates the profiles
 // variable when the --profiles flag was not used.

--- a/internal/compose/merge.go
+++ b/internal/compose/merge.go
@@ -47,25 +47,61 @@ func PreprocessStackRoot(stackDir string) func([]byte) []byte {
 	}
 }
 
+// extractPlatformOverlay extracts the x-dargstack.platform.<platform> section from
+// a parsed compose document and returns it as a standalone document with its contents
+// promoted to root level. Returns nil if the platform section doesn't exist.
+func extractPlatformOverlay(doc map[interface{}]interface{}, platform string) map[interface{}]interface{} {
+	xds, ok := doc["x-dargstack"]
+	if !ok {
+		return nil
+	}
+	xdsMap, ok := xds.(map[interface{}]interface{})
+	if !ok {
+		return nil
+	}
+
+	platformRaw, ok := xdsMap["platform"]
+	if !ok {
+		return nil
+	}
+	platformMap, ok := platformRaw.(map[interface{}]interface{})
+	if !ok {
+		return nil
+	}
+
+	overlayRaw, ok := platformMap[platform]
+	if !ok {
+		return nil
+	}
+	overlay, ok := overlayRaw.(map[interface{}]interface{})
+	if !ok {
+		return nil
+	}
+
+	return overlay
+}
+
 // MergeFiles merges multiple compose YAML files using spruce.
 // Later files override earlier ones. Spruce operators like (( prune )) are evaluated.
-// stackDir is the stack project root directory containing dargstack.yaml, used for
-// expanding the "~~" and "~~~" prefixes in path values.
-func MergeFiles(stackDir string, paths ...string) ([]byte, error) {
-	return mergeFiles(nil, stackDir, paths...)
+// stackDir is the stack project root directory used for expanding the "~~" and "~~~" prefixes.
+// platform is the target OS (e.g. "darwin", "linux"); if non-empty, x-dargstack.platform.<platform>
+// sections are extracted and merged as higher-priority overlays.
+func MergeFiles(stackDir, platform string, paths ...string) ([]byte, error) {
+	return mergeFiles(nil, stackDir, platform, paths...)
 }
 
 // MergeFilesProduction merges compose YAML files like MergeFiles but strips
 // # dargstack:dev-only markers from each file's raw bytes before YAML parsing.
-// This must be called before the YAML roundtrip, since YAML parsers discard comments.
-func MergeFilesProduction(stackDir string, paths ...string) ([]byte, error) {
-	return mergeFiles(StripDevOnlyMarkers, stackDir, paths...)
+// platform is the target OS for x-dargstack.platform overrides.
+func MergeFilesProduction(stackDir, platform string, paths ...string) ([]byte, error) {
+	return mergeFiles(StripDevOnlyMarkers, stackDir, platform, paths...)
 }
 
 // mergeFiles is the shared implementation for MergeFiles and MergeFilesProduction.
 // preProcess, when non-nil, is applied to each file's raw bytes before YAML parsing.
 // stackDir is the stack project root directory used for expanding the "~~" and "~~~" prefixes.
-func mergeFiles(preProcess func([]byte) []byte, stackDir string, paths ...string) ([]byte, error) {
+// platform is the target OS for x-dargstack.platform overrides.
+func mergeFiles(preProcess func([]byte) []byte, stackDir, platform string, paths ...string) ([]byte, error) {
 	if len(paths) == 0 {
 		return nil, fmt.Errorf("no compose files provided")
 	}
@@ -104,6 +140,14 @@ func mergeFiles(preProcess func([]byte) []byte, stackDir string, paths ...string
 		resolveFilePaths(doc, filepath.Dir(p))
 
 		docs = append(docs, doc)
+
+		// Inject platform-specific overlay as a higher-priority document.
+		if platform != "" {
+			if overlay := extractPlatformOverlay(doc, platform); overlay != nil {
+				resolveFilePaths(overlay, filepath.Dir(p))
+				docs = append(docs, overlay)
+			}
+		}
 	}
 
 	// Spruce deep merge: later documents override earlier ones.
@@ -140,7 +184,8 @@ func mergeFiles(preProcess func([]byte) []byte, stackDir string, paths ...string
 
 // LoadSingle loads a single compose file without merging, resolving relative paths.
 // stackDir is the stack project root directory used for expanding the "~~" and "~~~" prefixes.
-func LoadSingle(stackDir, path string) ([]byte, error) {
+// platform is the target OS for x-dargstack.platform overrides.
+func LoadSingle(stackDir, platform, path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read %s: %w", path, err)
@@ -157,6 +202,30 @@ func LoadSingle(stackDir, path string) ([]byte, error) {
 	}
 
 	resolveFilePaths(v2doc, filepath.Dir(path))
+
+	// Apply platform overlay if specified.
+	if platform != "" {
+		if overlay := extractPlatformOverlay(v2doc, platform); overlay != nil {
+			resolveFilePaths(overlay, filepath.Dir(path))
+			merged, err := spruce.Merge(v2doc, overlay)
+			if err != nil {
+				return nil, fmt.Errorf("merge platform overlay %s: %w", path, err)
+			}
+			ev := &spruce.Evaluator{Tree: merged}
+			if err := ev.Run(nil, nil); err != nil {
+				return nil, fmt.Errorf("evaluate platform overlay %s: %w", path, err)
+			}
+			v2out, err := yamlv2.Marshal(ev.Tree)
+			if err != nil {
+				return nil, fmt.Errorf("serialize %s: %w", path, err)
+			}
+			var v3doc interface{}
+			if err := yaml.Unmarshal(v2out, &v3doc); err != nil {
+				return nil, fmt.Errorf("re-parse %s: %w", path, err)
+			}
+			return yaml.Marshal(v3doc)
+		}
+	}
 
 	v2out, err := yamlv2.Marshal(v2doc)
 	if err != nil {

--- a/internal/compose/merge_test.go
+++ b/internal/compose/merge_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMergeFilesNoFiles(t *testing.T) {
-	_, err := MergeFiles("")
+	_, err := MergeFiles("", "")
 	if err == nil {
 		t.Fatal("expected error for zero files")
 	}
@@ -29,7 +29,7 @@ func TestMergeFilesSingleFile(t *testing.T) {
 	f := filepath.Join(dir, "base.yaml")
 	writeTestFile(t, f, "services:\n  web:\n    image: nginx\n")
 
-	out, err := MergeFiles("", f)
+	out, err := MergeFiles("", "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestMergeFilesOverride(t *testing.T) {
 	writeTestFile(t, base, "services:\n  web:\n    image: nginx:1.0\n    environment:\n      DEBUG: \"true\"\n")
 	writeTestFile(t, overlay, "services:\n  web:\n    image: nginx:2.0\n")
 
-	out, err := MergeFiles("", base, overlay)
+	out, err := MergeFiles("", "", base, overlay)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestMergeFilesPruneOperator(t *testing.T) {
 	writeTestFile(t, base, "services:\n  web:\n    image: nginx\n    environment:\n      DEBUG: \"true\"\n")
 	writeTestFile(t, overlay, "services:\n  web:\n    environment:\n      DEBUG: (( prune ))\n")
 
-	out, err := MergeFiles("", base, overlay)
+	out, err := MergeFiles("", "", base, overlay)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestMergeFilesPruneOperator(t *testing.T) {
 }
 
 func TestMergeFileMissing(t *testing.T) {
-	_, err := MergeFiles("", "/nonexistent/file.yaml")
+	_, err := MergeFiles("", "", "/nonexistent/file.yaml")
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -95,7 +95,7 @@ func TestMergeFileInvalidYAML(t *testing.T) {
 	f := filepath.Join(dir, "bad.yaml")
 	writeTestFile(t, f, "{{not valid yaml")
 
-	_, err := MergeFiles("", f)
+	_, err := MergeFiles("", "", f)
 	if err == nil {
 		t.Fatal("expected error for invalid YAML")
 	}
@@ -107,7 +107,7 @@ func TestLoadSingle(t *testing.T) {
 	content := "services:\n  web:\n    image: nginx\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle("", f)
+	out, err := LoadSingle("", "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestLoadSingle(t *testing.T) {
 }
 
 func TestLoadSingleMissing(t *testing.T) {
-	_, err := LoadSingle("", "/nonexistent/compose.yaml")
+	_, err := LoadSingle("", "", "/nonexistent/compose.yaml")
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -141,7 +141,7 @@ func TestLoadSingleInvalidYAML(t *testing.T) {
 	f := filepath.Join(dir, "bad.yaml")
 	writeTestFile(t, f, "{{not valid")
 
-	_, err := LoadSingle("", f)
+	_, err := LoadSingle("", "", f)
 	if err == nil {
 		t.Fatal("expected error for invalid YAML")
 	}
@@ -533,7 +533,7 @@ func TestExpandStackRootInSecrets(t *testing.T) {
 	content := "secrets:\n  my-secret:\n    file: " + StackRootPrefix + "/artifacts/secrets/my.secret\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -552,7 +552,7 @@ func TestExpandStackRootInBuildLabel(t *testing.T) {
 	content := "services:\n  api:\n    image: api\n    deploy:\n      labels:\n        - dargstack.development.build=" + StackRootPrefix + "/../api\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -570,7 +570,7 @@ func TestExpandStackRootInVolume(t *testing.T) {
 	content := "services:\n  api:\n    image: api\n    volumes:\n      - " + StackRootPrefix + "/../api:/srv/app\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,7 +592,7 @@ func TestExpandStackRootEmptySuffix(t *testing.T) {
 	content := "services:\n  api:\n    image: api\n    environment:\n      STACK_DIR: \"" + StackRootPrefix + "\"\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -609,7 +609,7 @@ func TestExpandStackRootNoExpansion(t *testing.T) {
 
 	writeTestFile(t, f, "services:\n  api:\n    image: nginx\n")
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -630,7 +630,7 @@ func TestExpandStackRootWithMerge(t *testing.T) {
 	writeTestFile(t, base, baseContent)
 	writeTestFile(t, overlay, overlayContent)
 
-	out, err := MergeFiles(stackDir, base, overlay)
+	out, err := MergeFiles(stackDir, "", base, overlay)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -654,7 +654,7 @@ func TestExpandParentDirInSecret(t *testing.T) {
 	content := "secrets:\n  app-secret:\n    file: " + ParentDirPrefix + "/shared/app.secret\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,7 +674,7 @@ func TestExpandParentDirInVolume(t *testing.T) {
 	content := "services:\n  api:\n    image: api\n    volumes:\n      - " + ParentDirPrefix + "/api:/srv/app\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -682,6 +682,72 @@ func TestExpandParentDirInVolume(t *testing.T) {
 	want := filepath.Join(parentDir, "api")
 	if !strings.Contains(string(out), want) {
 		t.Errorf("expected volume path to contain %q, got:\n%s", want, string(out))
+	}
+}
+
+func TestExtractPlatformOverlayFound(t *testing.T) {
+	doc := map[interface{}]interface{}{
+		"services": map[interface{}]interface{}{
+			"cadvisor": map[interface{}]interface{}{
+				"image": "cadvisor:latest",
+			},
+		},
+		"x-dargstack": map[interface{}]interface{}{
+			"platform": map[interface{}]interface{}{
+				"darwin": map[interface{}]interface{}{
+					"services": map[interface{}]interface{}{
+						"cadvisor": map[interface{}]interface{}{
+							"privileged": false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	overlay := extractPlatformOverlay(doc, "darwin")
+	if overlay == nil {
+		t.Fatal("expected overlay for darwin, got nil")
+	}
+
+	services, ok := overlay["services"].(map[interface{}]interface{})
+	if !ok {
+		t.Fatal("expected services in overlay")
+	}
+	cadvisor, ok := services["cadvisor"].(map[interface{}]interface{})
+	if !ok {
+		t.Fatal("expected cadvisor in overlay")
+	}
+	if cadvisor["privileged"] != false {
+		t.Errorf("expected privileged=false, got %v", cadvisor["privileged"])
+	}
+}
+
+func TestExtractPlatformOverlayNotFound(t *testing.T) {
+	doc := map[interface{}]interface{}{
+		"services": map[interface{}]interface{}{},
+	}
+
+	overlay := extractPlatformOverlay(doc, "darwin")
+	if overlay != nil {
+		t.Error("expected nil overlay when platform section missing")
+	}
+}
+
+func TestExtractPlatformOverlayWrongPlatform(t *testing.T) {
+	doc := map[interface{}]interface{}{
+		"x-dargstack": map[interface{}]interface{}{
+			"platform": map[interface{}]interface{}{
+				"linux": map[interface{}]interface{}{
+					"services": map[interface{}]interface{}{},
+				},
+			},
+		},
+	}
+
+	overlay := extractPlatformOverlay(doc, "darwin")
+	if overlay != nil {
+		t.Error("expected nil overlay when requesting darwin but only linux defined")
 	}
 }
 
@@ -694,7 +760,7 @@ func TestExpandBothPrefixes(t *testing.T) {
 	content := "services:\n  api:\n    image: api\n    volumes:\n      - " + StackRootPrefix + "/local:/local\n      - " + ParentDirPrefix + "/shared:/shared\n"
 	writeTestFile(t, f, content)
 
-	out, err := LoadSingle(stackDir, f)
+	out, err := LoadSingle(stackDir, "", f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -704,5 +770,212 @@ func TestExpandBothPrefixes(t *testing.T) {
 	}
 	if !strings.Contains(string(out), parentDir) {
 		t.Errorf("expected volume path to contain parent dir %q, got:\n%s", parentDir, string(out))
+	}
+}
+
+func TestMergeFilesPlatformOverlay(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "compose.yaml")
+
+	content := `services:
+  cadvisor:
+    image: cadvisor:latest
+    volumes:
+      - /:/rootfs:ro
+      - /dev/disk/by-id/:/dev/disk/by-id:ro
+    privileged: true
+x-dargstack:
+  platform:
+    darwin:
+      services:
+        cadvisor:
+          volumes:
+            - (( prune ))
+            - /:/rootfs:ro
+          privileged: false
+`
+	writeTestFile(t, f, content)
+
+	out, err := MergeFiles("", "darwin", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		t.Fatal(err)
+	}
+
+	services, ok := doc["services"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected services map")
+	}
+	cadvisor, ok := services["cadvisor"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected cadvisor service")
+	}
+
+	if cadvisor["privileged"] != false {
+		t.Errorf("expected privileged=false after darwin overlay, got %v", cadvisor["privileged"])
+	}
+
+	volumes, ok := cadvisor["volumes"].([]interface{})
+	if !ok {
+		t.Fatal("expected volumes list")
+	}
+	if len(volumes) != 1 {
+		t.Fatalf("expected 1 volume after prune+override, got %d", len(volumes))
+	}
+	if volumes[0] != "/:/rootfs:ro" {
+		t.Errorf("expected /:/rootfs:ro, got %v", volumes[0])
+	}
+}
+
+func TestLoadSinglePlatformOverlay(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "compose.yaml")
+	content := `services:
+    web:
+      image: nginx
+      privileged: true
+x-dargstack:
+    platform:
+      darwin:
+        services:
+          web:
+            privileged: false
+  `
+	writeTestFile(t, f, content)
+	out, err := LoadSingle("", "darwin", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		t.Fatal(err)
+	}
+	services, ok := doc["services"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected services map")
+	}
+	web, ok := services["web"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected web service")
+	}
+	if web["privileged"] != false {
+		t.Errorf("expected privileged=false after darwin overlay, got %v", web["privileged"])
+	}
+}
+
+func TestMergeFilesPlatformNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "compose.yaml")
+
+	content := `services:
+  cadvisor:
+    image: cadvisor:latest
+    privileged: true
+x-dargstack:
+  platform:
+    darwin:
+      services:
+        cadvisor:
+          privileged: false
+`
+	writeTestFile(t, f, content)
+
+	out, err := MergeFiles("", "linux", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(out), "privileged: true") {
+		t.Error("expected privileged=true when platform doesn't match overlay")
+	}
+}
+
+func TestMergeFilesPlatformEmptyPlatform(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "compose.yaml")
+
+	content := `services:
+  web:
+    image: nginx
+    privileged: true
+x-dargstack:
+  platform:
+    darwin:
+      services:
+        web:
+          privileged: false
+`
+	writeTestFile(t, f, content)
+
+	out, err := MergeFiles("", "", f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(out), "nginx") {
+		t.Error("expected web service in output")
+	}
+}
+
+func TestMergeFilesPlatformMultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.yaml")
+	overlay := filepath.Join(dir, "overlay.yaml")
+
+	writeTestFile(t, base, `services:
+  cadvisor:
+    image: cadvisor:latest
+    volumes:
+      - /:/rootfs:ro
+      - /dev/disk/by-id/:/dev/disk/by-id:ro
+    privileged: true
+x-dargstack:
+  platform:
+    darwin:
+      services:
+        cadvisor:
+          privileged: false
+`)
+
+	writeTestFile(t, overlay, `services:
+  cadvisor:
+    volumes:
+      - (( prune ))
+      - /:/rootfs:ro
+`)
+
+	out, err := MergeFiles("", "darwin", base, overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		t.Fatal(err)
+	}
+
+	services, ok := doc["services"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected services map")
+	}
+	cadvisor, ok := services["cadvisor"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected cadvisor service")
+	}
+
+	if cadvisor["privileged"] != false {
+		t.Errorf("expected privileged=false from platform overlay, got %v", cadvisor["privileged"])
+	}
+
+	volumes, ok := cadvisor["volumes"].([]interface{})
+	if !ok {
+		t.Fatal("expected volumes list")
+	}
+	if len(volumes) != 1 || volumes[0] != "/:/rootfs:ro" {
+		t.Errorf("expected single volume from file overlay, got %v", volumes)
 	}
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,16 @@
+package platform
+
+import "runtime"
+
+// Detect returns the current OS identifier (runtime.GOOS).
+func Detect() string {
+	return runtime.GOOS
+}
+
+// Get returns the platform override if non-empty, otherwise the detected OS.
+func Get(override string) string {
+	if override != "" {
+		return override
+	}
+	return Detect()
+}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,27 @@
+package platform
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestDetect(t *testing.T) {
+	got := Detect()
+	if got != runtime.GOOS {
+		t.Errorf("expected %q, got %q", runtime.GOOS, got)
+	}
+}
+
+func TestGetWithOverride(t *testing.T) {
+	got := Get("darwin")
+	if got != "darwin" {
+		t.Errorf("expected darwin, got %q", got)
+	}
+}
+
+func TestGetNoOverride(t *testing.T) {
+	got := Get("")
+	if got != runtime.GOOS {
+		t.Errorf("expected %q, got %q", runtime.GOOS, got)
+	}
+}


### PR DESCRIPTION
This pull request introduces support for platform-specific Docker Compose overrides by allowing users to specify a target platform (such as "darwin" or "linux") via a new `--platform` CLI flag. The Compose file merging and loading logic now detects and merges `x-dargstack.platform.<platform>` sections as overlays, enabling per-platform configuration.