### PR TITLE
fix: invalidate stale update cache after self-update

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -259,6 +259,20 @@ func readCache() *CheckResult {
 		return nil
 	}
 
+	// If the cache says an update was available, verify the current version
+	// isn't already at or past that version. This prevents stale cache hits
+	// after a self-update (e.g. user was on 4.6.0, cache says 4.7.0 available,
+	// user updates to 4.7.0, but cache still reports Available=true).
+	if entry.Available && entry.NewVersion != "" {
+		cur, cerr := semver.NewVersion(strings.TrimPrefix(currentVersion(), "v"))
+		cached, cachedErr := semver.NewVersion(entry.NewVersion)
+		if cerr == nil && cachedErr == nil {
+			if cur.GreaterThan(cached) || cur.Equal(cached) {
+				return nil
+			}
+		}
+	}
+
 	return &CheckResult{Available: entry.Available, NewVersion: entry.NewVersion}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -467,6 +467,59 @@ func TestReadCache_CacheDisabled(t *testing.T) {
 	}
 }
 
+func TestReadCache_StaleAfterUpdate(t *testing.T) {
+	cleanup := testSetup(t)
+	defer cleanup(t)
+
+	// Simulate: user was on 4.6.0, cache recorded 4.7.0 available.
+	// User self-updated to 4.7.0, cache should be treated as stale.
+	currentVersion = func() string { return "4.7.0" }
+	tmpDir := t.TempDir()
+	cacheDirFunc = func() (string, error) { return tmpDir, nil }
+
+	entry := cacheEntry{
+		Available:  true,
+		CheckedAt:  time.Now(),
+		NewVersion: "4.7.0",
+	}
+	data, _ := json.Marshal(entry)
+	path := filepath.Join(tmpDir, cacheFile)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readCache()
+	if result != nil {
+		t.Errorf("expected nil for stale cache (current version >= cached), got %+v", result)
+	}
+}
+
+func TestReadCache_StaleAfterUpdate_NewerCurrent(t *testing.T) {
+	cleanup := testSetup(t)
+	defer cleanup(t)
+
+	// Current version is newer than cached version.
+	currentVersion = func() string { return "5.0.0" }
+	tmpDir := t.TempDir()
+	cacheDirFunc = func() (string, error) { return tmpDir, nil }
+
+	entry := cacheEntry{
+		Available:  true,
+		CheckedAt:  time.Now(),
+		NewVersion: "4.7.0",
+	}
+	data, _ := json.Marshal(entry)
+	path := filepath.Join(tmpDir, cacheFile)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := readCache()
+	if result != nil {
+		t.Errorf("expected nil for stale cache (current version > cached), got %+v", result)
+	}
+}
+
 func TestWriteAndReadCache(t *testing.T) {
 	cleanup := testSetup(t)
 	defer cleanup(t)


### PR DESCRIPTION
## Problem

After running `dargstack update --self` to the latest version, subsequent commands showed an incorrect warning:

> Warning: A new version of dargstack is available: 4.7.0 -> 4.7.0
> Warning: Run `dargstack update --self` to update.

## Root Cause

The update check result is cached for 24 hours. When the user was on an older version (e.g. 4.6.0), the cache stored `Available: true, NewVersion: "4.7.0"`. After self-updating to 4.7.0, `readCache()` returned the stale entry without verifying the current version against the cached result.

## Fix

`readCache()` now compares the current version against the cached `NewVersion` when `Available` is `true`. If the current version is already >= the cached version, the cache entry is treated as stale and `nil` is returned, forcing a fresh network check.

## Tests

Added two new tests:
- `TestReadCache_StaleAfterUpdate` — current version equals cached version
- `TestReadCache_StaleAfterUpdate_NewerCurrent` — current version exceeds cached version

Fixes #103