### PR TITLE
fix(deploy): log image checks

### DIFF
--- a/internal/cli/deploy_run.go
+++ b/internal/cli/deploy_run.go
@@ -245,15 +245,34 @@ func deployPreDeployChecks(executor *docker.Executor, composeData []byte, dryRun
 		if len(images) > 0 {
 			logger.L.Info(fmt.Sprintf("[dry-run] Would check image accessibility for: %s", strings.Join(images, ", ")))
 		}
-	} else {
-		if len(images) > 0 {
-			unreachable := docker.CheckImagesAccessible(executor, images)
-			if len(unreachable) > 0 {
-				for img := range unreachable {
-					logger.L.Error(fmt.Sprintf("image not accessible: %s", img))
-				}
-				return nil, fmt.Errorf("one or more images are not accessible — fix registry credentials or image references before deploying")
+	} else if len(images) > 0 {
+		if verbose {
+			logger.L.Info(fmt.Sprintf("Checking image accessibility for %d image(s) in parallel: %s", len(images), strings.Join(images, ", ")))
+		}
+
+		var unreachable map[string]error
+		checkImages := func() {
+			unreachable = docker.CheckImagesAccessible(executor, images)
+		}
+
+		if verbose {
+			checkImages()
+		} else {
+			if err := spinner.New().Title("Checking image accessibility").Action(checkImages).Run(); err != nil {
+				return nil, err
 			}
+		}
+
+		if len(unreachable) > 0 {
+			unreachableImages := make([]string, 0, len(unreachable))
+			for img := range unreachable {
+				unreachableImages = append(unreachableImages, img)
+			}
+			sort.Strings(unreachableImages)
+			for _, img := range unreachableImages {
+				logger.L.Error(fmt.Sprintf("image not accessible: %s: %v", img, unreachable[img]))
+			}
+			return nil, fmt.Errorf("one or more images are not accessible — fix registry credentials or image references before deploying")
 		}
 	}
 

--- a/internal/docker/registry.go
+++ b/internal/docker/registry.go
@@ -1,15 +1,42 @@
 package docker
 
+import "sync"
+
 // CheckImagesAccessible probes the registry for each image by inspecting its
-// manifest without pulling any layers. Returns a map from image name to error
-// for every image that is not reachable (wrong credentials, missing tag, etc.).
-// Checks run sequentially to avoid concurrent sudo credential prompts.
+// manifest without pulling any layers. Returns a map from image name to
+// error for every image that is not reachable (wrong credentials, missing
+// tag, etc.).
+//
+// The first check runs synchronously before the rest are fanned out in
+// parallel. If sudo credentials have expired, Executor.Run's refresh may
+// prompt interactively; running one check first ensures that prompt happens
+// once, rather than from multiple goroutines contending for stdin.
 func CheckImagesAccessible(exec *Executor, images []string) map[string]error {
 	failed := make(map[string]error)
-	for _, img := range images {
-		if _, err := exec.Run("manifest", "inspect", img); err != nil {
-			failed[img] = err
-		}
+	if len(images) == 0 {
+		return failed
 	}
+
+	first, rest := images[0], images[1:]
+	if _, err := exec.Run("manifest", "inspect", first); err != nil {
+		failed[first] = err
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for _, img := range rest {
+		wg.Add(1)
+		go func(img string) {
+			defer wg.Done()
+			if _, err := exec.Run("manifest", "inspect", img); err != nil {
+				mu.Lock()
+				failed[img] = err
+				mu.Unlock()
+			}
+		}(img)
+	}
+	wg.Wait()
+
 	return failed
 }


### PR DESCRIPTION
This pull request improves the image accessibility checks during deployment by making them run in parallel, significantly speeding up the process when multiple images are involved. It also enhances user feedback with more detailed and sorted logging, especially in verbose mode.

**Parallelization and Performance Improvements:**

* [`internal/docker/registry.go`](diffhunk://#diff-3c5e7311e2cff203983b5b140e1b305f5f91017ac92927c155b7ee6ce61383ceR3-R27): Refactored `CheckImagesAccessible` to check image accessibility in parallel using goroutines and a wait group, instead of the previous sequential approach. This leverages prewarmed sudo credentials for efficiency.

**User Experience Enhancements:**

* [`internal/cli/deploy_run.go`](diffhunk://#diff-5abcc2ec115a9f3c46a8e5ff99b9df62ca564268425e06c0da330b8a02fe58e1R248-L258): Improved logging to indicate when image checks are running in parallel and added verbose mode messages.
* [`internal/cli/deploy_run.go`](diffhunk://#diff-5abcc2ec115a9f3c46a8e5ff99b9df62ca564268425e06c0da330b8a02fe58e1R248-L258): Sorted and clearly reported any images that are not accessible, making errors easier to read and debug.