### PR TITLE
feat(agent): add skill management

### DIFF
--- a/docs/dargstack.md
+++ b/docs/dargstack.md
@@ -34,6 +34,7 @@ dargstack - simplified, approachable Docker Swarm stack management.
 * [dargstack profiles](dargstack_profiles.md)	 - List discovered deploy profiles
 * [dargstack remove](dargstack_remove.md)	 - Remove the deployed stack
 * [dargstack secret](dargstack_secret.md)	 - Manage stack secrets
+* [dargstack skill](dargstack_skill.md)	 - Manage the dargstack AI agent skill
 * [dargstack update](dargstack_update.md)	 - Update dargstack to the latest version
 * [dargstack validate](dargstack_validate.md)	 - Validate stack resources
 

--- a/docs/dargstack_skill.md
+++ b/docs/dargstack_skill.md
@@ -1,21 +1,22 @@
-## dargstack update
+## dargstack skill
 
-Update dargstack to the latest version
+Manage the dargstack AI agent skill
 
 ### Synopsis
 
-Downloads and installs the latest release of dargstack. Requires --self flag.
+Manage the dargstack AI agent skill.
 
-```
-dargstack update [flags]
-```
+The skill teaches AI agents about dargstack conventions: project structure,
+spruce operators, secret templating, label semantics, and deploy workflow.
+
+Install the skill globally (~/.agents/skills/dargstack/) or project-local
+(.agents/skills/dargstack/) with --project.
 
 ### Options
 
 ```
-  -h, --help       help for update
-      --no-skill   skip updating the agent skill
-      --self       update dargstack itself
+  -h, --help      help for skill
+      --project   use project-local .agents/skills/ instead of global ~/.agents/skills/
 ```
 
 ### Options inherited from parent commands
@@ -36,4 +37,8 @@ dargstack update [flags]
 ### SEE ALSO
 
 * [dargstack](dargstack.md)	 - Docker stack helper CLI
+* [dargstack skill install](dargstack_skill_install.md)	 - Install the dargstack agent skill
+* [dargstack skill status](dargstack_skill_status.md)	 - Show the status of the installed dargstack agent skill
+* [dargstack skill uninstall](dargstack_skill_uninstall.md)	 - Uninstall the dargstack agent skill
+* [dargstack skill update](dargstack_skill_update.md)	 - Update the dargstack agent skill to the current bundled version
 

--- a/docs/dargstack_skill_install.md
+++ b/docs/dargstack_skill_install.md
@@ -1,21 +1,15 @@
-## dargstack update
+## dargstack skill install
 
-Update dargstack to the latest version
-
-### Synopsis
-
-Downloads and installs the latest release of dargstack. Requires --self flag.
+Install the dargstack agent skill
 
 ```
-dargstack update [flags]
+dargstack skill install [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help       help for update
-      --no-skill   skip updating the agent skill
-      --self       update dargstack itself
+  -h, --help   help for install
 ```
 
 ### Options inherited from parent commands
@@ -30,10 +24,11 @@ dargstack update [flags]
   -o, --offline                skip fetching remote resources
       --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
+      --project                use project-local .agents/skills/ instead of global ~/.agents/skills/
   -s, --services strings       filter to specific services
 ```
 
 ### SEE ALSO
 
-* [dargstack](dargstack.md)	 - Docker stack helper CLI
+* [dargstack skill](dargstack_skill.md)	 - Manage the dargstack AI agent skill
 

--- a/docs/dargstack_skill_status.md
+++ b/docs/dargstack_skill_status.md
@@ -1,21 +1,15 @@
-## dargstack update
+## dargstack skill status
 
-Update dargstack to the latest version
-
-### Synopsis
-
-Downloads and installs the latest release of dargstack. Requires --self flag.
+Show the status of the installed dargstack agent skill
 
 ```
-dargstack update [flags]
+dargstack skill status [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help       help for update
-      --no-skill   skip updating the agent skill
-      --self       update dargstack itself
+  -h, --help   help for status
 ```
 
 ### Options inherited from parent commands
@@ -30,10 +24,11 @@ dargstack update [flags]
   -o, --offline                skip fetching remote resources
       --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
+      --project                use project-local .agents/skills/ instead of global ~/.agents/skills/
   -s, --services strings       filter to specific services
 ```
 
 ### SEE ALSO
 
-* [dargstack](dargstack.md)	 - Docker stack helper CLI
+* [dargstack skill](dargstack_skill.md)	 - Manage the dargstack AI agent skill
 

--- a/docs/dargstack_skill_uninstall.md
+++ b/docs/dargstack_skill_uninstall.md
@@ -1,21 +1,15 @@
-## dargstack update
+## dargstack skill uninstall
 
-Update dargstack to the latest version
-
-### Synopsis
-
-Downloads and installs the latest release of dargstack. Requires --self flag.
+Uninstall the dargstack agent skill
 
 ```
-dargstack update [flags]
+dargstack skill uninstall [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help       help for update
-      --no-skill   skip updating the agent skill
-      --self       update dargstack itself
+  -h, --help   help for uninstall
 ```
 
 ### Options inherited from parent commands
@@ -30,10 +24,11 @@ dargstack update [flags]
   -o, --offline                skip fetching remote resources
       --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
+      --project                use project-local .agents/skills/ instead of global ~/.agents/skills/
   -s, --services strings       filter to specific services
 ```
 
 ### SEE ALSO
 
-* [dargstack](dargstack.md)	 - Docker stack helper CLI
+* [dargstack skill](dargstack_skill.md)	 - Manage the dargstack AI agent skill
 

--- a/docs/dargstack_skill_update.md
+++ b/docs/dargstack_skill_update.md
@@ -1,21 +1,15 @@
-## dargstack update
+## dargstack skill update
 
-Update dargstack to the latest version
-
-### Synopsis
-
-Downloads and installs the latest release of dargstack. Requires --self flag.
+Update the dargstack agent skill to the current bundled version
 
 ```
-dargstack update [flags]
+dargstack skill update [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help       help for update
-      --no-skill   skip updating the agent skill
-      --self       update dargstack itself
+  -h, --help   help for update
 ```
 
 ### Options inherited from parent commands
@@ -30,10 +24,11 @@ dargstack update [flags]
   -o, --offline                skip fetching remote resources
       --platform string        target platform for compose overrides (default: auto-detect)
   -p, --profiles strings       activate one or more compose profiles (or set COMPOSE_PROFILES env var); unlabeled services are included unless a 'default' profile is defined
+      --project                use project-local .agents/skills/ instead of global ~/.agents/skills/
   -s, --services strings       filter to specific services
 ```
 
 ### SEE ALSO
 
-* [dargstack](dargstack.md)	 - Docker stack helper CLI
+* [dargstack skill](dargstack_skill.md)	 - Manage the dargstack AI agent skill
 

--- a/internal/cli/initialize.go
+++ b/internal/cli/initialize.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dargstack/dargstack/v4/internal/config"
 	"github.com/dargstack/dargstack/v4/internal/giturl"
 	"github.com/dargstack/dargstack/v4/internal/logger"
 	"github.com/dargstack/dargstack/v4/internal/prompt"
@@ -131,6 +132,15 @@ func cloneProject(url, target string) error {
 		return fmt.Errorf("git clone: %w", err)
 	}
 	logger.Success(fmt.Sprintf("Project cloned into %s", displayTarget))
+
+	stackDir, detectErr := config.DetectStackDirIn(target)
+	if detectErr == nil {
+		projectCfg, cfgErr := config.Load(stackDir)
+		if cfgErr == nil {
+			autoInstallSkill(projectCfg)
+		}
+	}
+
 	logger.L.Info("Run `cd` into the directory and then `dargstack deploy` to start.")
 	return nil
 }
@@ -226,6 +236,12 @@ func bootstrapProject(name, target string) error {
 	}
 
 	logger.Success(fmt.Sprintf("Project %q bootstrapped at %s", name, stackDir))
+
+	projectCfg, cfgErr := config.Load(stackDir)
+	if cfgErr == nil {
+		autoInstallSkill(projectCfg)
+	}
+
 	logger.L.Info(fmt.Sprintf("Next steps:\n  cd %s\n  dargstack deploy", stackDir))
 	return nil
 }

--- a/internal/cli/initialize.go
+++ b/internal/cli/initialize.go
@@ -447,11 +447,11 @@ greeting: Hello from dargstack!
 // initHelloProdCompose is the production overlay for the example hello service.
 // It demonstrates the three most useful Spruce merge operators:
 //   - plain key overwrite (image tag)
-//   - (( purge )) to remove a development-only key
+//   - (( prune )) to remove a development-only key
 //   - (( append )) to extend a list without replacing it
 const initHelloProdCompose = `# Production overrides for the hello service.
 # Spruce operators used here:
-#   (( purge ))  — remove this key from the merged result
+#   (( prune ))  — remove this key from the merged result
 #   (( append )) — append to the list instead of replacing it
 # All other keys simply overwrite the development value.
 
@@ -466,7 +466,7 @@ secrets:
 services:
   hello:
     image: %s/hello:latest   # overwrite: pin to a versioned release tag
-    ports: (( purge ))       # purge: no direct port binding in production (use an ingress)
+    ports: (( prune ))       # purge: no direct port binding in production (use an ingress)
     deploy:
       labels:
         - (( append ))       # append: keep existing dev labels and add new ones

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -146,6 +146,7 @@ func init() {
 	rootCmd.AddCommand(profilesCmd)
 	rootCmd.AddCommand(rmCmd)
 	rootCmd.AddCommand(secretCmd)
+	rootCmd.AddCommand(skillCmd)
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(validateCmd)
 }
@@ -159,6 +160,7 @@ func isUpdateSkippedCommand(cmd *cobra.Command) bool {
 	skipped := map[string]bool{
 		"completion": true,
 		"help":       true,
+		"skill":      true,
 		"update":     true,
 	}
 	for c := cmd; c != nil; c = c.Parent() {
@@ -178,6 +180,7 @@ func isSkippedCommand(cmd *cobra.Command) bool {
 		"help":       true,
 		"init":       true,
 		"initialize": true,
+		"skill":      true,
 		"update":     true,
 	}
 	// Walk up from the leaf command to the first child of root.

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/dargstack/dargstack/v4/internal/config"
+	"github.com/dargstack/dargstack/v4/internal/logger"
+	"github.com/dargstack/dargstack/v4/internal/skill"
+)
+
+var skillProject bool
+
+var skillCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage the dargstack AI agent skill",
+	Long: `Manage the dargstack AI agent skill.
+
+The skill teaches AI agents about dargstack conventions: project structure,
+spruce operators, secret templating, label semantics, and deploy workflow.
+
+Install the skill globally (~/.agents/skills/dargstack/) or project-local
+(.agents/skills/dargstack/) with --project.`,
+}
+
+var skillInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install the dargstack agent skill",
+	RunE:  runSkillInstall,
+}
+
+var skillUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall the dargstack agent skill",
+	RunE:  runSkillUninstall,
+}
+
+var skillUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update the dargstack agent skill to the current bundled version",
+	RunE:  runSkillUpdate,
+}
+
+var skillStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show the status of the installed dargstack agent skill",
+	RunE:  runSkillStatus,
+}
+
+func init() {
+	skillCmd.AddCommand(skillInstallCmd)
+	skillCmd.AddCommand(skillUninstallCmd)
+	skillCmd.AddCommand(skillUpdateCmd)
+	skillCmd.AddCommand(skillStatusCmd)
+
+	skillCmd.PersistentFlags().BoolVar(&skillProject, "project", false, "use project-local .agents/skills/ instead of global ~/.agents/skills/")
+}
+
+func runSkillInstall(_ *cobra.Command, _ []string) error {
+	skillDir, err := skill.SkillPath(skillProject)
+	if err != nil {
+		return err
+	}
+
+	updated, modified, err := skill.Install(skillDir)
+	if err != nil {
+		return fmt.Errorf("install skill: %w", err)
+	}
+
+	if modified {
+		logger.L.Warn("Installed skill has been modified. Run `dargstack skill update` to overwrite with the bundled version.")
+		displayDir := skillDir
+		if !filepath.IsAbs(skillDir) {
+			displayDir = "./" + skillDir
+		}
+		fmt.Printf("Skill already installed at %s (user-modified)\n", displayDir)
+		return nil
+	}
+
+	if updated {
+		displayDir := skillDir
+		if !filepath.IsAbs(skillDir) {
+			displayDir = "./" + skillDir
+		}
+		logger.Success(fmt.Sprintf("Skill installed at %s", displayDir))
+		return nil
+	}
+
+	displayDir := skillDir
+	if !filepath.IsAbs(skillDir) {
+		displayDir = "./" + skillDir
+	}
+	fmt.Printf("Skill already installed at %s (up to date)\n", displayDir)
+	return nil
+}
+
+func runSkillUninstall(_ *cobra.Command, _ []string) error {
+	skillDir, err := skill.SkillPath(skillProject)
+	if err != nil {
+		return err
+	}
+
+	if err := skill.Uninstall(skillDir); err != nil {
+		return err
+	}
+
+	logger.Success("Skill uninstalled")
+	return nil
+}
+
+func runSkillUpdate(_ *cobra.Command, _ []string) error {
+	skillDir, err := skill.SkillPath(skillProject)
+	if err != nil {
+		return err
+	}
+
+	updated, err := skill.Update(skillDir)
+	if err != nil {
+		return err
+	}
+
+	if updated {
+		logger.Success("Skill updated")
+	} else {
+		fmt.Println("Skill is already up to date")
+	}
+	return nil
+}
+
+func runSkillStatus(_ *cobra.Command, _ []string) error {
+	skillDir, err := skill.SkillPath(skillProject)
+	if err != nil {
+		return err
+	}
+
+	info, err := skill.Status(skillDir)
+	if err != nil {
+		return err
+	}
+
+	location := info.Location
+	if !filepath.IsAbs(info.Location) {
+		location = "./" + location
+	}
+
+	trunc := func(h string) string {
+		if len(h) > 12 {
+			return h[:12] + "..."
+		}
+		return h
+	}
+
+	fmt.Printf("Location:    %s\n", location)
+	fmt.Printf("Bundled:     %s (%s)\n", info.BundledVer, trunc(info.BundledHash))
+
+	if !info.Installed {
+		fmt.Println("Installed:     no")
+		return nil
+	}
+
+	fmt.Printf("Installed:   %s (%s)\n", info.InstalledVer, trunc(info.InstalledHash))
+
+	switch {
+	case info.UserModified:
+		logger.L.Warn("Skill has been modified since installation")
+	case info.UpToDate:
+		logger.Success("Skill is up to date")
+	default:
+		logger.L.Info("A new version of the skill is available. Run `dargstack skill update` to update.")
+	}
+
+	return nil
+}
+
+// autoInstallSkill installs the skill based on the effective skill install mode.
+// Called by initialize and clone after project setup.
+func autoInstallSkill(projectCfg *config.Config) {
+	globalCfg, err := config.LoadGlobalConfig()
+	if err != nil {
+		logger.L.Warn(fmt.Sprintf("Could not read global config: %v", err))
+		return
+	}
+
+	mode := config.EffectiveSkillInstall(globalCfg, projectCfg)
+
+	switch mode {
+	case config.SkillInstallOff:
+		if !noInteraction {
+			logger.L.Info("Run `dargstack skill install` to help AI agents understand your stack.")
+		}
+	case config.SkillInstallOnce:
+		skillDir, dirErr := skill.SkillPath(false)
+		if dirErr != nil {
+			return
+		}
+		if !skill.IsInstalled(skillDir) {
+			updated, modified, installErr := skill.Install(skillDir)
+			if installErr != nil {
+				logger.L.Warn(fmt.Sprintf("Could not install skill: %v", installErr))
+				return
+			}
+			if updated && !modified {
+				logger.L.Info(fmt.Sprintf("Skill installed at %s", skillDir))
+			}
+		}
+	case config.SkillInstallAuto:
+		skillDir, dirErr := skill.SkillPath(false)
+		if dirErr != nil {
+			return
+		}
+		updated, modified, installErr := skill.Install(skillDir)
+		if installErr != nil {
+			logger.L.Warn(fmt.Sprintf("Could not install skill: %v", installErr))
+			return
+		}
+		if updated && !modified {
+			logger.L.Info(fmt.Sprintf("Skill installed at %s", skillDir))
+		} else if modified {
+			logger.L.Warn("Installed skill has been modified. Run `dargstack skill update` to overwrite.")
+		}
+	}
+}
+
+// autoUpdateSkill updates the skill after a binary self-update.
+// Returns true if the skill was updated, false otherwise.
+func autoUpdateSkill() bool {
+	globalCfg, err := config.LoadGlobalConfig()
+	if err != nil {
+		return false
+	}
+	if globalCfg.Runtime.Skill.Install != config.SkillInstallAuto {
+		return false
+	}
+
+	skillDir, dirErr := skill.SkillPath(false)
+	if dirErr != nil {
+		return false
+	}
+
+	updated, _, installErr := skill.Install(skillDir)
+	if installErr != nil {
+		logger.L.Warn(fmt.Sprintf("Could not update skill: %v", installErr))
+		return false
+	}
+
+	if updated {
+		logger.L.Info("Skill updated to match dargstack version")
+	}
+	return updated
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -7,6 +7,7 @@ import (
 )
 
 var updateSelf bool
+var updateNoSkill bool
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
@@ -17,11 +18,18 @@ var updateCmd = &cobra.Command{
 
 func init() {
 	updateCmd.Flags().BoolVar(&updateSelf, "self", false, "update dargstack itself")
+	updateCmd.Flags().BoolVar(&updateNoSkill, "no-skill", false, "skip updating the agent skill")
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
 	if !updateSelf {
 		return cmd.Help()
 	}
-	return update.SelfUpdate()
+	if err := update.SelfUpdate(); err != nil {
+		return err
+	}
+	if !updateNoSkill {
+		autoUpdateSkill()
+	}
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,6 +179,29 @@ func DetectStackDir() (string, error) {
 	}
 }
 
+// DetectStackDirIn searches for dargstack.yaml starting from the given
+// directory, walking up to its root. Unlike DetectStackDir, it does not
+// use the current working directory.
+func DetectStackDirIn(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve directory: %w", err)
+	}
+
+	for {
+		candidate := filepath.Join(dir, ConfigFileName)
+		if _, err := os.Stat(candidate); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("%s not found in %s or any parent", ConfigFileName, startDir)
+		}
+		dir = parent
+	}
+}
+
 func Load(stackDir string) (*Config, error) {
 	path := filepath.Join(stackDir, ConfigFileName)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,40 @@ func (b *BuildMode) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
+type SkillInstallMode string
+
+const (
+	SkillInstallAuto SkillInstallMode = "auto"
+	SkillInstallOnce SkillInstallMode = "once"
+	SkillInstallOff  SkillInstallMode = "off"
+)
+
+func (s *SkillInstallMode) UnmarshalYAML(node *yaml.Node) error {
+	var v interface{}
+	if err := node.Decode(&v); err != nil {
+		return err
+	}
+
+	switch raw := v.(type) {
+	case bool:
+		if raw {
+			*s = SkillInstallAuto
+		} else {
+			*s = SkillInstallOff
+		}
+	case string:
+		switch SkillInstallMode(raw) {
+		case SkillInstallAuto, SkillInstallOnce, SkillInstallOff:
+			*s = SkillInstallMode(raw)
+		default:
+			return fmt.Errorf("invalid skill install mode %q: must be auto, once, or off", raw)
+		}
+	default:
+		return fmt.Errorf("invalid skill install mode: expected bool or string, got %T", v)
+	}
+	return nil
+}
+
 type Config struct {
 	stackDir string
 
@@ -79,9 +113,14 @@ type SourceConfig struct {
 	URL  string `yaml:"url"`
 }
 
+type SkillConfig struct {
+	Install SkillInstallMode `yaml:"install"`
+}
+
 type RuntimeConfig struct {
 	Build  BuildConfig  `yaml:"build"`
 	Deploy DeployConfig `yaml:"deploy"`
+	Skill  SkillConfig  `yaml:"skill"`
 	Sudo   SudoMode     `yaml:"sudo"`
 }
 
@@ -192,6 +231,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Environment.Development.Domain == "" {
 		c.Environment.Development.Domain = "app.localhost"
+	}
+	if c.Runtime.Skill.Install == "" {
+		c.Runtime.Skill.Install = SkillInstallAuto
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -325,13 +325,13 @@ func TestCustomDomainOverride(t *testing.T) {
 func TestCertificateIncludeExclude(t *testing.T) {
 	dir := t.TempDir()
 	content := `environment:
-  development:
-    certificate:
-      exclude:
-        - admin.app.localhost
-      include:
-        - foo.example.com
-        - bar.local
+   development:
+     certificate:
+       exclude:
+         - admin.app.localhost
+       include:
+         - foo.example.com
+         - bar.local
 `
 	if err := os.WriteFile(filepath.Join(dir, ConfigFileName), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
@@ -350,6 +350,36 @@ func TestCertificateIncludeExclude(t *testing.T) {
 	}
 	if len(cfg.Environment.Development.Certificate.Include) != 2 {
 		t.Fatalf("expected 2 include, got %d", len(cfg.Environment.Development.Certificate.Include))
+	}
+}
+
+func TestDetectStackDirIn(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "stack", "src", "development")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "stack", ConfigFileName), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := DetectStackDirIn(subDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(dir, "stack")
+	resolvedFound, _ := filepath.EvalSymlinks(found)
+	resolvedExpected, _ := filepath.EvalSymlinks(expected)
+	if resolvedFound != resolvedExpected {
+		t.Errorf("expected %s, got %s", resolvedExpected, resolvedFound)
+	}
+}
+
+func TestDetectStackDirInNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := DetectStackDirIn(dir)
+	if err == nil {
+		t.Fatal("expected error when config not found")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -352,3 +352,111 @@ func TestCertificateIncludeExclude(t *testing.T) {
 		t.Fatalf("expected 2 include, got %d", len(cfg.Environment.Development.Certificate.Include))
 	}
 }
+
+func TestSkillInstallModeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		want    SkillInstallMode
+		wantErr bool
+	}{
+		{"bool true", "runtime:\n  skill:\n    install: true\n", SkillInstallAuto, false},
+		{"bool false", "runtime:\n  skill:\n    install: false\n", SkillInstallOff, false},
+		{"string auto", "runtime:\n  skill:\n    install: auto\n", SkillInstallAuto, false},
+		{"string once", "runtime:\n  skill:\n    install: once\n", SkillInstallOnce, false},
+		{"string off", "runtime:\n  skill:\n    install: off\n", SkillInstallOff, false},
+		{"invalid string", "runtime:\n  skill:\n    install: invalid\n", "", true},
+		{"default", "", SkillInstallAuto, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, ConfigFileName), []byte(tt.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(dir)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Runtime.Skill.Install != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, cfg.Runtime.Skill.Install)
+			}
+		})
+	}
+}
+
+func TestGlobalConfigLoad(t *testing.T) {
+	// Test with nonexistent file — should return defaults.
+	origHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	tmp := t.TempDir()
+	_ = os.Setenv("HOME", tmp)
+
+	cfg, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Runtime.Skill.Install != SkillInstallAuto {
+		t.Errorf("expected default auto, got %q", cfg.Runtime.Skill.Install)
+	}
+}
+
+func TestGlobalConfigLoadWithFile(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	defer func() { _ = os.Setenv("HOME", origHome) }()
+
+	tmp := t.TempDir()
+	_ = os.Setenv("HOME", tmp)
+
+	configDir := filepath.Join(tmp, ".config", "dargstack")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := "runtime:\n  skill:\n    install: once\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Runtime.Skill.Install != SkillInstallOnce {
+		t.Errorf("expected once, got %q", cfg.Runtime.Skill.Install)
+	}
+}
+
+func TestEffectiveSkillInstall(t *testing.T) {
+	global := &GlobalConfig{}
+	global.applyDefaults()
+	project := &Config{}
+	project.applyDefaults()
+
+	// Both defaults — should return auto.
+	if EffectiveSkillInstall(global, project) != SkillInstallAuto {
+		t.Error("expected auto when both are defaults")
+	}
+
+	// Global is once, project is default — should return once.
+	global.Runtime.Skill.Install = SkillInstallOnce
+	project.Runtime.Skill.Install = SkillInstallAuto
+	if EffectiveSkillInstall(global, project) != SkillInstallOnce {
+		t.Error("expected once when global is once and project is default")
+	}
+
+	// Global is auto, project is off — project wins.
+	global.Runtime.Skill.Install = SkillInstallAuto
+	project.Runtime.Skill.Install = SkillInstallOff
+	if EffectiveSkillInstall(global, project) != SkillInstallOff {
+		t.Error("expected off when project overrides global")
+	}
+}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	GlobalConfigDir  = ".config/dargstack"
+	GlobalConfigFile = "config.yaml"
+)
+
+// GlobalConfig mirrors the project Config structure for user-level settings.
+// Only a subset of fields is supported; unknown fields are ignored.
+type GlobalConfig struct {
+	Runtime struct {
+		Skill SkillConfig `yaml:"skill"`
+	} `yaml:"runtime"`
+}
+
+// GlobalConfigPath returns the path to the global config file.
+// Returns an empty string if the home directory is unavailable.
+func GlobalConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, GlobalConfigDir, GlobalConfigFile)
+}
+
+// LoadGlobalConfig reads and parses the global config file.
+// Returns a GlobalConfig with defaults applied. Missing file is not an error.
+func LoadGlobalConfig() (*GlobalConfig, error) {
+	cfg := &GlobalConfig{}
+	cfg.applyDefaults()
+
+	path := GlobalConfigPath()
+	if path == "" {
+		return cfg, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("read global config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse global config %s: %w", path, err)
+	}
+	cfg.applyDefaults()
+
+	return cfg, nil
+}
+
+func (c *GlobalConfig) applyDefaults() {
+	if c.Runtime.Skill.Install == "" {
+		c.Runtime.Skill.Install = SkillInstallAuto
+	}
+}
+
+// EffectiveSkillInstall returns the effective skill install mode.
+// Project config overrides global config. If the project config has a
+// non-default value, it takes precedence. Otherwise, global config is used.
+func EffectiveSkillInstall(global *GlobalConfig, project *Config) SkillInstallMode {
+	// If project config explicitly set a non-default value, use it.
+	if project.Runtime.Skill.Install != SkillInstallAuto {
+		return project.Runtime.Skill.Install
+	}
+	return global.Runtime.Skill.Install
+}

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: dargstack
+description: Understand dargstack project structure, spruce operators, secret templating, label conventions, and deploy workflow for AI agents working in dargstack-managed Docker Swarm projects.
+metadata:
+  dargstack_version: "4.0.0"
+---
+
+# Dargstack Agent Skill
+
+## Project Structure
+
+A dargstack project has this layout:
+
+```
+project/
+├── stack/                          # dargstack project root
+│   ├── dargstack.yaml              # project configuration
+│   ├── src/
+│   │   ├── development/            # base service definitions
+│   │   │   ├── <service>/
+│   │   │   │   ├── compose.yaml    # full Docker Compose document
+│   │   │   │   ├── config.yaml     # file-based config volume
+│   │   │   │   └── *.secret        # secret files
+│   │   │   └── .env                # environment variables
+│   │   └── production/             # production overrides (differences only)
+│   │       ├── <service>/
+│   │       │   ├── compose.yaml    # spruce deep-merge override
+│   │       │   └── config.yaml     # replaces development config
+│   │       └── .env                # extends development env vars
+│   └── artifacts/                  # generated outputs
+│       ├── audit-log/              # deployment snapshots (gitignored)
+│       ├── certificates/           # TLS certificates (gitignored)
+│       ├── secrets/                # Docker secrets (gitignored)
+│       └── docs/                   # generated documentation
+├── <service>/                       # service source code (sibling to stack/)
+│   ├── Dockerfile
+│   └── ...
+└── README.md
+```
+
+**Key rules:**
+- `stack/dargstack.yaml` is the project configuration file
+- Each service gets its own directory under `src/<environment>/`
+- Service directories contain `compose.yaml` plus any config/secret files
+- Production files contain only **differences** from development — they are deep-merged on top
+- Service source code lives as a sibling to `stack/`, not inside it
+
+## Spruce Operators
+
+Service files are deep-merged using [spruce](https://github.com/geofffranks/spruce). Production `compose.yaml` files use these operators:
+
+| Operator | Effect |
+|----------|--------|
+| `(( purge ))` | Remove this key entirely from the merged result |
+| `(( append ))` | Append to a list instead of replacing it |
+| `(( merge ))` | Deep merge maps recursively |
+| `(( omit ))` | Skip this key during merge |
+| `(( keep ))` | Keep the original value, ignore the override |
+| `(( ref <path> ))` | Reference a value from another part of the document |
+
+**Example — production override:**
+
+```yaml
+services:
+  api:
+    image: ghcr.io/org/api:v1.0.0    # overwrite: pin image tag
+    ports: (( purge ))                # remove direct port binding
+    deploy:
+      labels:
+        - (( append ))                # keep dev labels, add new ones
+        - "traefik.enable=true"
+      replicas: 3                     # overwrite: scale up
+```
+
+**Example — development-only lines:**
+
+Lines annotated with `# dargstack:dev-only` in development files are stripped before the production merge.
+
+```yaml
+services:
+  api:
+    deploy:
+      labels:
+        - some.label=for-development # dargstack:dev-only
+```
+
+## Secret Templating
+
+Secrets are defined in `x-dargstack.secrets` within `compose.yaml`:
+
+```yaml
+x-dargstack:
+  secrets:
+    api-key:
+      type: random_string
+      length: 32
+      special_characters: false
+    db-password:
+      type: template
+      template: "postgresql://user:{{secret:api-key}}@host:5432/db"
+    signing-key:
+      type: private_key
+      key_type: ed25519
+    external-token:
+      type: third_party
+      hint: "Get at https://example.com/tokens"
+    dev-secret:
+      type: insecure_default
+      insecure_default: "CHANGE_ME"
+```
+
+**Secret types:**
+- `random_string` — auto-generated random string (configurable length, special characters)
+- `wordlist_word` — auto-generated word from a wordlist
+- `private_key` — auto-generated private key (ed25519, rsa, ecdsa)
+- `third_party` — requires manual value; `hint` guides the user
+- `insecure_default` — uses the provided default value
+- `template` — composed from tokens like `{{secret:name}}`, `{{random_string}}`, `{{wordlist_word}}`, `{{private_key}}`
+
+Secret files (`.secret` extension) live alongside `compose.yaml` in the service directory.
+
+## Label Conventions
+
+Special labels in `deploy.labels` control dargstack behavior:
+
+| Label | Purpose |
+|-------|---------|
+| `dargstack.development.build` | Build context path (relative to `stack/src/development/<service>/`) |
+| `dargstack.development.git.ssh` | SSH git URL to clone before building |
+| `dargstack.development.git.https` | HTTPS git URL fallback for cloning |
+| `dargstack.profiles` | Profile membership (comma-separated) |
+
+Git-cloned repositories go to a sibling directory of `stack/`, named after the repository.
+
+## Profiles
+
+Services can belong to profiles via `dargstack.profiles` label. Deploy with `--profiles <name>`.
+
+- Unlabeled services are always deployed unless any service declares `default`
+- If `default` is declared, only `default`-labeled services deploy by default
+- Explicit `--profiles` only deploys matching services; use `--profiles unlabeled` to include unlabeled ones
+
+## Deploy Workflow
+
+1. `dargstack deploy` — merges compose files, resolves secrets, builds images, deploys to Docker Swarm
+2. `dargstack build` — build development images only
+3. `dargstack validate` — validate compose files and resources
+4. `dargstack secret generate` — generate secrets from templates
+5. `dargstack remove` — remove the deployed stack
+6. `dargstack audit` — view deployment history
+
+Use `--environment production` for production deployments. Use `--dry-run` to trace without executing.
+
+## Platform Overrides
+
+Platform-specific compose modifications live under `x-dargstack.platform.<os>` in development `compose.yaml`:
+
+```yaml
+x-dargstack:
+  platform:
+    darwin:
+      services:
+        cadvisor:
+          privileged: false
+          volumes:
+            - (( prune ))
+```
+
+Supported platforms: `darwin`, `linux`, `windows`. Active platform is auto-detected or overridden with `--platform`.

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -51,7 +51,7 @@ Service files are deep-merged using [spruce](https://github.com/geofffranks/spru
 
 | Operator | Effect |
 |----------|--------|
-| `(( purge ))` | Remove this key entirely from the merged result |
+| `(( prune ))` | Remove this key entirely from the merged result |
 | `(( append ))` | Append to a list instead of replacing it |
 | `(( merge ))` | Deep merge maps recursively |
 | `(( omit ))` | Skip this key during merge |
@@ -64,7 +64,7 @@ Service files are deep-merged using [spruce](https://github.com/geofffranks/spru
 services:
   api:
     image: ghcr.io/org/api:v1.0.0    # overwrite: pin image tag
-    ports: (( purge ))                # remove direct port binding
+    ports: (( prune ))                # remove direct port binding
     deploy:
       labels:
         - (( append ))                # keep dev labels, add new ones

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,0 +1,232 @@
+package skill
+
+import (
+	"crypto/sha256"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dargstack/dargstack/v4/internal/version"
+)
+
+//go:embed SKILL.md
+var bundledSkill string
+
+const (
+	skillName     = "dargstack"
+	skillFileName = "SKILL.md"
+	metaFileName  = ".dargstack-meta"
+	skillsDirName = ".agents/skills"
+)
+
+// Meta stores version and hash of an installed skill.
+type Meta struct {
+	Version string `json:"version"`
+	SHA256  string `json:"sha256"`
+}
+
+// BundledContent returns the embedded SKILL.md content.
+func BundledContent() string { return bundledSkill }
+
+// BundledHash returns the sha256 hex digest of the embedded skill content.
+func BundledHash() string {
+	h := sha256.Sum256([]byte(bundledSkill))
+	return fmt.Sprintf("%x", h)
+}
+
+// BundledVersion returns the dargstack version associated with the bundled skill.
+func BundledVersion() string { return version.Version }
+
+// SkillPath returns the path to the skill directory.
+// If project is true, uses .agents/skills/ in the current working directory.
+// Otherwise, uses ~/.agents/skills/.
+func SkillPath(project bool) (string, error) {
+	if project {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("get working directory: %w", err)
+		}
+		return filepath.Join(cwd, skillsDirName, skillName), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+	return filepath.Join(home, skillsDirName, skillName), nil
+}
+
+// SkillFilePath returns the path to SKILL.md in the given skill directory.
+func SkillFilePath(skillDir string) string {
+	return filepath.Join(skillDir, skillFileName)
+}
+
+// MetaFilePath returns the path to .dargstack-meta in the given skill directory.
+func MetaFilePath(skillDir string) string {
+	return filepath.Join(skillDir, metaFileName)
+}
+
+// ReadMeta reads the metadata file from the skill directory.
+// Returns nil Meta and nil error if the file doesn't exist.
+func ReadMeta(skillDir string) (*Meta, error) {
+	path := MetaFilePath(skillDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read metadata: %w", err)
+	}
+	var meta Meta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parse metadata: %w", err)
+	}
+	return &meta, nil
+}
+
+// WriteMeta writes version and hash metadata to the skill directory.
+func WriteMeta(skillDir, ver, hash string) error {
+	meta := Meta{Version: ver, SHA256: hash}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshal metadata: %w", err)
+	}
+	path := MetaFilePath(skillDir)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write metadata: %w", err)
+	}
+	return nil
+}
+
+// IsInstalled returns true if the skill directory exists and contains SKILL.md.
+func IsInstalled(skillDir string) bool {
+	_, err := os.Stat(SkillFilePath(skillDir))
+	return err == nil
+}
+
+// Install installs or updates the skill at the given directory.
+// Returns (updated bool, userModified bool, error).
+// updated is true if the file was written.
+// userModified is true if the existing file's hash differs from both the
+// previous bundled hash and the current bundled hash.
+func Install(skillDir string) (updated, userModified bool, err error) {
+	existingMeta, err := ReadMeta(skillDir)
+	if err != nil {
+		return false, false, err
+	}
+
+	bHash := BundledHash()
+	skillPath := SkillFilePath(skillDir)
+
+	// Check for user modifications first.
+	if existingMeta != nil {
+		currentData, readErr := os.ReadFile(skillPath)
+		if readErr == nil {
+			currentHash := fmt.Sprintf("%x", sha256.Sum256(currentData))
+			if currentHash != existingMeta.SHA256 && currentHash != bHash {
+				return false, true, nil
+			}
+		}
+	}
+
+	// Check if already up to date.
+	if existingMeta != nil && existingMeta.SHA256 == bHash {
+		return false, false, nil
+	}
+
+	// Create directory if needed.
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return false, false, fmt.Errorf("create skill directory: %w", err)
+	}
+
+	// Write skill file.
+	if err := os.WriteFile(skillPath, []byte(bundledSkill), 0o644); err != nil {
+		return false, false, fmt.Errorf("write skill file: %w", err)
+	}
+
+	// Write metadata.
+	if err := WriteMeta(skillDir, BundledVersion(), bHash); err != nil {
+		return false, false, err
+	}
+
+	return true, false, nil
+}
+
+// Uninstall removes the skill directory and metadata.
+// Returns error if the skill is not installed or metadata is missing.
+func Uninstall(skillDir string) error {
+	meta, err := ReadMeta(skillDir)
+	if err != nil {
+		return err
+	}
+	if meta == nil {
+		return fmt.Errorf("skill is not installed (no metadata found)")
+	}
+	if !IsInstalled(skillDir) {
+		return fmt.Errorf("skill is not installed (missing %s)", skillFileName)
+	}
+	if err := os.RemoveAll(skillDir); err != nil {
+		return fmt.Errorf("remove skill directory: %w", err)
+	}
+	return nil
+}
+
+// Update updates the skill if the bundled version differs from the installed one.
+// Returns (updated bool, error). Errors if not already installed.
+func Update(skillDir string) (bool, error) {
+	meta, err := ReadMeta(skillDir)
+	if err != nil {
+		return false, err
+	}
+	if meta == nil {
+		return false, fmt.Errorf("skill is not installed at %s", skillDir)
+	}
+	updated, _, err := Install(skillDir)
+	return updated, err
+}
+
+// StatusInfo holds the status of an installed skill.
+type StatusInfo struct {
+	Installed     bool
+	Location      string
+	BundledVer    string
+	BundledHash   string
+	InstalledVer  string
+	InstalledHash string
+	UpToDate      bool
+	UserModified  bool
+}
+
+// Status returns information about the installed skill.
+func Status(skillDir string) (*StatusInfo, error) {
+	info := &StatusInfo{
+		Location:    skillDir,
+		BundledVer:  BundledVersion(),
+		BundledHash: BundledHash(),
+	}
+
+	if !IsInstalled(skillDir) {
+		return info, nil
+	}
+
+	meta, err := ReadMeta(skillDir)
+	if err != nil {
+		return nil, err
+	}
+	if meta != nil {
+		info.Installed = true
+		info.InstalledVer = meta.Version
+		info.InstalledHash = meta.SHA256
+		info.UpToDate = meta.SHA256 == BundledHash()
+
+		// Check for user modifications.
+		currentData, readErr := os.ReadFile(SkillFilePath(skillDir))
+		if readErr == nil {
+			currentHash := fmt.Sprintf("%x", sha256.Sum256(currentData))
+			info.UserModified = currentHash != meta.SHA256 && currentHash != BundledHash()
+		}
+	}
+
+	return info, nil
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -130,9 +130,11 @@ func Install(skillDir string) (updated, userModified bool, err error) {
 		}
 	}
 
-	// Check if already up to date.
+	// Check if already up to date and skill file still exists.
 	if existingMeta != nil && existingMeta.SHA256 == bHash {
-		return false, false, nil
+		if _, statErr := os.Stat(skillPath); statErr == nil {
+			return false, false, nil
+		}
 	}
 
 	// Create directory if needed.
@@ -163,9 +165,7 @@ func Uninstall(skillDir string) error {
 	if meta == nil {
 		return fmt.Errorf("skill is not installed (no metadata found)")
 	}
-	if !IsInstalled(skillDir) {
-		return fmt.Errorf("skill is not installed (missing %s)", skillFileName)
-	}
+	// Allow uninstall to clean up partial installs even if SKILL.md is missing.
 	if err := os.RemoveAll(skillDir); err != nil {
 		return fmt.Errorf("remove skill directory: %w", err)
 	}
@@ -182,8 +182,26 @@ func Update(skillDir string) (bool, error) {
 	if meta == nil {
 		return false, fmt.Errorf("skill is not installed at %s", skillDir)
 	}
-	updated, _, err := Install(skillDir)
-	return updated, err
+
+	updated, userModified, err := Install(skillDir)
+	if err != nil {
+		return false, err
+	}
+	if !userModified {
+		return updated, nil
+	}
+	// Explicit update should overwrite user modifications.
+	bHash := BundledHash()
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return false, fmt.Errorf("create skill directory: %w", err)
+	}
+	if err := os.WriteFile(SkillFilePath(skillDir), []byte(bundledSkill), 0o644); err != nil {
+		return false, fmt.Errorf("write skill file: %w", err)
+	}
+	if err := WriteMeta(skillDir, BundledVersion(), bHash); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // StatusInfo holds the status of an installed skill.

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,0 +1,272 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBundledContent(t *testing.T) {
+	content := BundledContent()
+	if content == "" {
+		t.Fatal("bundled content is empty")
+	}
+	if content[0] != '-' {
+		t.Fatal("content does not start with frontmatter delimiter")
+	}
+}
+
+func TestBundledHash(t *testing.T) {
+	hash := BundledHash()
+	if hash == "" {
+		t.Fatal("bundled hash is empty")
+	}
+	// sha256 hex is 64 characters
+	if len(hash) != 64 {
+		t.Errorf("expected hash length 64, got %d", len(hash))
+	}
+}
+
+func TestSkillPathGlobal(t *testing.T) {
+	path, err := SkillPath(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("expected absolute path, got %s", path)
+	}
+	expected := filepath.Join(os.Getenv("HOME"), ".agents", "skills", "dargstack")
+	resolved, _ := filepath.EvalSymlinks(path)
+	resolvedExpected, _ := filepath.EvalSymlinks(expected)
+	if resolved != resolvedExpected {
+		t.Errorf("expected %s, got %s", resolvedExpected, resolved)
+	}
+}
+
+func TestSkillPathProject(t *testing.T) {
+	origDir, _ := os.Getwd()
+	defer func() { _ = os.Chdir(origDir) }()
+
+	tmp := t.TempDir()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := SkillPath(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(tmp, ".agents", "skills", "dargstack")
+	resolvedPath, _ := filepath.EvalSymlinks(path)
+	resolvedExpected, _ := filepath.EvalSymlinks(expected)
+	if resolvedPath != resolvedExpected {
+		t.Errorf("expected %s, got %s", resolvedExpected, resolvedPath)
+	}
+}
+
+func TestInstallAndIsInstalled(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	if IsInstalled(skillDir) {
+		t.Fatal("expected not installed before install")
+	}
+
+	updated, modified, err := Install(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("expected updated=true on first install")
+	}
+	if modified {
+		t.Fatal("expected modified=false on first install")
+	}
+	if !IsInstalled(skillDir) {
+		t.Fatal("expected installed after install")
+	}
+
+	// Second install should be no-op.
+	updated, modified, err = Install(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("expected updated=false when already current")
+	}
+	if modified {
+		t.Fatal("expected modified=false when already current")
+	}
+}
+
+func TestInstallDetectsUserModification(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	if _, _, err := Install(skillDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Modify the skill file.
+	skillPath := SkillFilePath(skillDir)
+	if err := os.WriteFile(skillPath, []byte("# user edited"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, modified, err := Install(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("expected updated=false when user modified")
+	}
+	if !modified {
+		t.Fatal("expected modified=true when user modified")
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	if _, _, err := Install(skillDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Uninstall(skillDir); err != nil {
+		t.Fatal(err)
+	}
+	if IsInstalled(skillDir) {
+		t.Fatal("expected not installed after uninstall")
+	}
+}
+
+func TestUninstallNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	err := Uninstall(skillDir)
+	if err == nil {
+		t.Fatal("expected error when uninstalling non-installed skill")
+	}
+}
+
+func TestUpdateNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	updated, err := Update(skillDir)
+	if err == nil {
+		t.Fatal("expected error when updating non-installed skill")
+	}
+	if updated {
+		t.Fatal("expected updated=false on error")
+	}
+}
+
+func TestUpdateInstalled(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	if _, _, err := Install(skillDir); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := Update(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("expected updated=false when already current")
+	}
+}
+
+func TestStatusNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	info, err := Status(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Installed {
+		t.Fatal("expected not installed")
+	}
+	if info.UpToDate {
+		t.Fatal("expected not up to date")
+	}
+}
+
+func TestStatusInstalled(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	if _, _, err := Install(skillDir); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := Status(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Installed {
+		t.Fatal("expected installed")
+	}
+	if !info.UpToDate {
+		t.Fatal("expected up to date")
+	}
+	if info.UserModified {
+		t.Fatal("expected not user modified")
+	}
+}
+
+func TestStatusUserModified(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	if _, _, err := Install(skillDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Modify the skill file.
+	if err := os.WriteFile(SkillFilePath(skillDir), []byte("# edited"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := Status(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.UserModified {
+		t.Fatal("expected user modified")
+	}
+}
+
+func TestReadMeta(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "dargstack")
+
+	// Nonexistent.
+	meta, err := ReadMeta(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta != nil {
+		t.Fatal("expected nil meta for nonexistent file")
+	}
+
+	// After install.
+	if _, _, err := Install(skillDir); err != nil {
+		t.Fatal(err)
+	}
+	meta, err = ReadMeta(skillDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta == nil {
+		t.Fatal("expected non-nil meta after install")
+	}
+	if meta.SHA256 != BundledHash() {
+		t.Errorf("meta hash mismatch: %s != %s", meta.SHA256, BundledHash())
+	}
+}


### PR DESCRIPTION
This pull request introduces a new "skill" command to the `dargstack` CLI for managing the AI agent skill, and integrates automatic skill installation and update logic into project initialization and self-update flows. It also documents the new commands and configuration options, and adds support for configuring skill installation behavior in the stack configuration.

The most important changes are:

**New CLI commands for skill management:**
* Added the `skill` command group with subcommands: `install`, `uninstall`, `update`, and `status`, allowing users to manage the dargstack AI agent skill directly from the CLI.
* Registered the `skill` command with the CLI and ensured it is excluded from update checks.

**Automatic skill installation and update:**
* On project initialization (both clone and bootstrap), the CLI now attempts to auto-install the skill based on the effective configuration, improving the onboarding experience for new users.
* After a self-update (`dargstack update --self`), the skill will be updated automatically unless explicitly skipped with `--no-skill`.

**Configuration and detection enhancements:**
* Introduced a new `SkillInstallMode` and `SkillConfig` in the stack configuration, allowing users to control skill installation behavior.
* Added `DetectStackDirIn` to locate the stack config file from a given directory, used during initialization.

**Documentation updates:**
* Added documentation for the new `skill` command and all its subcommands.
* Updated the main command list to include `skill` and documented the new `--no-skill` option for `dargstack update`.

These changes provide a more integrated and user-friendly way to manage the dargstack AI agent skill, making it easier for users to keep their AI agent knowledge up to date and ensuring better support for AI-driven workflows.