### PR TITLE
fix(deploy): don't fetch when offline

### DIFF
--- a/internal/cli/deploy_image.go
+++ b/internal/cli/deploy_image.go
@@ -90,18 +90,25 @@ func gitCheckout(dir, ref string) error {
 // and checks it out in stackDir so the compose files that get deployed
 // actually match the tagged release, rather than whatever happened to be on
 // disk. The checkout is left in place (detached at the tag) after deploy.
+// When offline, it only resolves the tag from local state without checking
+// out — the working tree is left as-is.
 func checkoutDeployTag() (string, error) {
+	tag, err := resolveDeployTag()
+	if err != nil {
+		return "", err
+	}
+
+	if offline {
+		logger.L.Info(fmt.Sprintf("Using local tag %q for production deploy (--offline)", tag))
+		return tag, nil
+	}
+
 	dirty, err := gitWorkingTreeDirty(stackDir)
 	if err != nil {
 		return "", fmt.Errorf("check git working tree status: %w", err)
 	}
 	if dirty {
 		return "", fmt.Errorf("stack directory has uncommitted changes to tracked files — commit or stash them before deploying to production")
-	}
-
-	tag, err := resolveDeployTag()
-	if err != nil {
-		return "", err
 	}
 
 	if err := gitCheckout(stackDir, tag); err != nil {

--- a/internal/cli/deploy_image_test.go
+++ b/internal/cli/deploy_image_test.go
@@ -302,7 +302,7 @@ func TestCheckoutDeployTagChecksOutTag(t *testing.T) {
 	}()
 
 	deployTag = "v1.0.0"
-	offline = true
+	offline = false
 	cfg = &config.Config{}
 	stackDir = dir
 
@@ -316,6 +316,41 @@ func TestCheckoutDeployTagChecksOutTag(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(dir, "file.txt")); !os.IsNotExist(err) {
 		t.Error("expected working tree to reflect v1.0.0, but file.txt from the later commit is present")
+	}
+}
+
+func TestCheckoutDeployTagSkipsCheckoutWhenOffline(t *testing.T) {
+	dir := t.TempDir()
+	setupGitRepo(t, dir)
+	runGit(t, dir, "tag", "v1.0.0")
+
+	// Dirty the tree — should NOT error when offline
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("changed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDeployTag := deployTag
+	origOffline := offline
+	origCfg := cfg
+	origStackDir := stackDir
+	defer func() {
+		deployTag = origDeployTag
+		offline = origOffline
+		cfg = origCfg
+		stackDir = origStackDir
+	}()
+
+	deployTag = "v1.0.0"
+	offline = true
+	cfg = &config.Config{}
+	stackDir = dir
+
+	tag, err := checkoutDeployTag()
+	if err != nil {
+		t.Fatalf("checkoutDeployTag should not error when offline: %v", err)
+	}
+	if tag != "v1.0.0" {
+		t.Errorf("expected v1.0.0, got %s", tag)
 	}
 }
 
@@ -340,7 +375,7 @@ func TestCheckoutDeployTagRejectsDirtyTree(t *testing.T) {
 	}()
 
 	deployTag = "v1.0.0"
-	offline = true
+	offline = false
 	cfg = &config.Config{}
 	stackDir = dir
 


### PR DESCRIPTION
This pull request updates the production deployment logic to better handle offline mode and improves test coverage for these scenarios. The most important changes are:

**Deployment logic improvements:**

* Modified `checkoutDeployTag` to skip checking out the git tag and only resolve it from local state when in offline mode, leaving the working tree as-is. This prevents errors due to uncommitted changes when deploying offline. 

**Testing updates:**

* Updated and renamed the test to verify that `checkoutDeployTag` skips the checkout and does not error in offline mode, even if the working tree is dirty.
* Restored and adjusted the original test to confirm that, when not in offline mode, `checkoutDeployTag` still rejects a dirty working tree as expected.
* Fixed the test configuration to ensure the correct offline/online state is set for each test.