### PR TITLE
fix(deploy): correct environment file templates

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -223,14 +223,18 @@ ending in `# dargstack:dev-only` is stripped before production deployment.
 ### Environment files
 
 v3 concatenated `src/development/stack.env` and `src/production/production.env`
-into `src/production/stack.env` during `derive`. v4 uses independent `.env`
-files per environment:
+into `src/production/stack.env` during `derive`. v4 uses `.env.template` files
+(tracked in version control) per environment, with corresponding `.env` files
+(gitignored) holding actual values:
 
-- `src/development/.env` — development variables
-- `src/production/.env` — production overrides (key=value pairs that override development values)
+- `src/development/.env.template` — development variable keys (tracked)
+- `src/development/.env` — development values (gitignored, auto-created from template)
+- `src/production/.env.template` — production override keys (tracked)
+- `src/production/.env` — production values (gitignored, auto-created from template)
 
-Rename `src/development/stack.env` → `src/development/.env` and
-`src/production/production.env` → `src/production/.env`.
+Rename `src/development/stack.env` to `src/development/.env.template` and
+`src/production/production.env` to `src/production/.env.template`. Add `.env` to
+`src/development/.gitignore` and `src/production/.gitignore`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ example/
 │   │   │   │   ├── configuration.toml  # File-based volume mount
 │   │   │   │   ├── key.secret          # Secret used by the service
 │   │   │   │   └── ...
-│   │   │   └── .env                    # Environment variables
+│   │   │   └── .env.template       # Environment variable keys (tracked)
 │   │   └── production/
 │   │       ├── api/
 │   │       │   ├── compose.yaml        # YAML deep-merge override
 │   │       │   ├── configuration.toml  # File-based override
 │   │       │   └── ...
-│   │       └── .env                    # Key-based override
+│   │       └── .env.template       # Key-based override (tracked)
 │   └── dargstack.yaml                  # Project configuration
 └── ...
 ```
@@ -330,7 +330,7 @@ x-dargstack:
 
 ### Environment Files
 
-`.env` files use `KEY=VALUE` format. During deploy, missing values are prompted. Production blocks on missing values.
+`.env.template` files (tracked in version control) define the keys your stack needs. On first deploy, dargstack copies each `.env.template` to `.env` (gitignored), which holds actual values. During deploy, missing values are prompted. Production blocks on missing values.
 
 ### Platform Overrides
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ Understanding these decisions will help you make changes that align with dargsta
 
 6. **Service directories** — each service lives in its own directory under `src/{development,production}/<service-name>/` containing a `compose.yaml` plus co-located resources (secrets, configs, Dockerfiles). Each `compose.yaml` is a full, valid Docker Compose document. Relative `file:` paths and `build.context` are resolved to absolute paths during merge.
 
-7. **Environment file merging** — dev `.env` and prod `.env` are merged for production (prod values override). Missing values are prompted; production blocks on missing values.
+7. **Environment file merging** — dev `.env` and prod `.env` are merged for production (prod values override). `.env` is gitignored; `.env.template` is tracked and copied to `.env` on first deploy. Missing values are prompted; production blocks on missing values.
 
 8. **STACK_DOMAIN** — defaults to `app.localhost`; configurable. TLS cert covers all discovered subdomains.
 

--- a/internal/cli/deploy_run.go
+++ b/internal/cli/deploy_run.go
@@ -45,6 +45,18 @@ func runDeployWithExecutor(ctx context.Context, _ *cobra.Command, dockerClient *
 		_ = os.Setenv("STACK_DOMAIN", stackDomain)
 	}
 
+	// Ensure .env files exist (copied from .env.template if missing).
+	// Done after production checkout so the template matches the deployed revision.
+	// Skipped in dry-run mode to avoid side effects.
+	if !dryRun {
+		if err := compose.EnsureEnvFile(cfg.DevEnvFile(), cfg.DevEnvTemplate()); err != nil {
+			return fmt.Errorf("ensure dev env file: %w", err)
+		}
+		if err := compose.EnsureEnvFile(cfg.ProdEnvFile(), cfg.ProdEnvTemplate()); err != nil {
+			return fmt.Errorf("ensure prod env file: %w", err)
+		}
+	}
+
 	composeData, err := buildComposeData(isProduction())
 	if err != nil {
 		return wrapWithBugHint(err)

--- a/internal/cli/initialize.go
+++ b/internal/cli/initialize.go
@@ -186,12 +186,16 @@ func bootstrapProject(name, target string) error {
 		return fmt.Errorf("write artifacts/README.md: %w", err)
 	}
 
-	for _, envFile := range []string{
-		filepath.Join(stackDir, "src", "development", ".env"),
-		filepath.Join(stackDir, "src", "production", ".env"),
+	// Create .env.template (tracked) and .gitignore (ignores .env with real values).
+	for _, dir := range []string{
+		filepath.Join(stackDir, "src", "development"),
+		filepath.Join(stackDir, "src", "production"),
 	} {
-		if err := os.WriteFile(envFile, []byte("# Add environment variables here (KEY=VALUE)\n"), 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", envFile, err)
+		if err := os.WriteFile(filepath.Join(dir, ".env.template"), []byte("# Add environment variables here (KEY=VALUE)\n"), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", dir+"/.env.template", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".env\n"), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", dir+"/.gitignore", err)
 		}
 	}
 

--- a/internal/compose/env.go
+++ b/internal/compose/env.go
@@ -8,6 +8,29 @@ import (
 	"strings"
 )
 
+// EnsureEnvFile copies templatePath to envPath if envPath does not exist.
+// If templatePath does not exist, it creates envPath with a minimal placeholder comment.
+func EnsureEnvFile(envPath, templatePath string) error {
+	_, err := os.Stat(envPath)
+	if err == nil {
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("stat env file %s: %w", envPath, err)
+	}
+
+	data, err := os.ReadFile(templatePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read env template %s: %w", templatePath, err)
+	}
+
+	if os.IsNotExist(err) {
+		data = []byte("# Add environment variables here (KEY=VALUE)\n")
+	}
+
+	return os.WriteFile(envPath, data, 0o644)
+}
+
 // MergeEnvFiles merges .env files from development and production.
 // Production values override development values. Returns merged content.
 func MergeEnvFiles(devEnv, prodEnv string) ([]byte, error) {

--- a/internal/compose/merge_test.go
+++ b/internal/compose/merge_test.go
@@ -979,3 +979,62 @@ x-dargstack:
 		t.Errorf("expected single volume from file overlay, got %v", volumes)
 	}
 }
+
+func TestEnsureEnvFileCreatesFromTemplate(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	templatePath := filepath.Join(dir, ".env.template")
+
+	writeTestFile(t, templatePath, "FOO=bar\nBAZ=qux\n")
+
+	if err := EnsureEnvFile(envPath, templatePath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "FOO=bar\nBAZ=qux\n" {
+		t.Errorf("expected template contents, got %q", string(data))
+	}
+}
+
+func TestEnsureEnvFileNoOpWhenEnvExists(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	templatePath := filepath.Join(dir, ".env.template")
+
+	writeTestFile(t, envPath, "EXISTING=value\n")
+	writeTestFile(t, templatePath, "FOO=bar\n")
+
+	if err := EnsureEnvFile(envPath, templatePath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "EXISTING=value\n" {
+		t.Errorf("expected existing contents preserved, got %q", string(data))
+	}
+}
+
+func TestEnsureEnvFileCreatesDefaultTemplateWhenTemplateMissing(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	templatePath := filepath.Join(dir, ".env.template")
+
+	if err := EnsureEnvFile(envPath, templatePath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "KEY=VALUE") {
+		t.Errorf("expected default template, got %q", string(data))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -302,12 +302,18 @@ func (c *Config) ArtifactsDir() string { return filepath.Join(c.stackDir, "artif
 func (c *Config) CertificatesDir() string {
 	return filepath.Join(c.stackDir, "artifacts", "certificates")
 }
-func (c *Config) DevDir() string      { return filepath.Join(c.stackDir, "src", "development") }
-func (c *Config) DevEnvFile() string  { return filepath.Join(c.stackDir, "src", "development", ".env") }
+func (c *Config) DevDir() string     { return filepath.Join(c.stackDir, "src", "development") }
+func (c *Config) DevEnvFile() string { return filepath.Join(c.stackDir, "src", "development", ".env") }
+func (c *Config) DevEnvTemplate() string {
+	return filepath.Join(c.stackDir, "src", "development", ".env.template")
+}
 func (c *Config) ProdDir() string     { return filepath.Join(c.stackDir, "src", "production") }
 func (c *Config) ProdEnvFile() string { return filepath.Join(c.stackDir, "src", "production", ".env") }
-func (c *Config) SecretsDir() string  { return filepath.Join(c.stackDir, "artifacts", "secrets") }
-func (c *Config) StackDir() string    { return c.stackDir }
+func (c *Config) ProdEnvTemplate() string {
+	return filepath.Join(c.stackDir, "src", "production", ".env.template")
+}
+func (c *Config) SecretsDir() string { return filepath.Join(c.stackDir, "artifacts", "secrets") }
+func (c *Config) StackDir() string   { return c.stackDir }
 
 // CollectServiceFiles returns the paths to compose.yaml files in the given
 // directory. It includes the shared compose.yaml at the directory root if it

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -225,7 +225,9 @@ func TestPathHelpers(t *testing.T) {
 		{"CertificatesDir", cfg.CertificatesDir(), filepath.Join(resolved, "artifacts", "certificates")},
 		{"SecretsDir", cfg.SecretsDir(), filepath.Join(resolved, "artifacts", "secrets")},
 		{"DevEnvFile", cfg.DevEnvFile(), filepath.Join(resolved, "src", "development", ".env")},
+		{"DevEnvTemplate", cfg.DevEnvTemplate(), filepath.Join(resolved, "src", "development", ".env.template")},
 		{"ProdEnvFile", cfg.ProdEnvFile(), filepath.Join(resolved, "src", "production", ".env")},
+		{"ProdEnvTemplate", cfg.ProdEnvTemplate(), filepath.Join(resolved, "src", "production", ".env.template")},
 	}
 
 	for _, tt := range tests {

--- a/internal/skill/SKILL.md
+++ b/internal/skill/SKILL.md
@@ -21,12 +21,12 @@ project/
 │   │   │   │   ├── compose.yaml    # full Docker Compose document
 │   │   │   │   ├── config.yaml     # file-based config volume
 │   │   │   │   └── *.secret        # secret files
-│   │   │   └── .env                # environment variables
+│   │   │   └── .env.template       # environment variable keys (tracked)
 │   │   └── production/             # production overrides (differences only)
 │   │       ├── <service>/
 │   │       │   ├── compose.yaml    # spruce deep-merge override
 │   │       │   └── config.yaml     # replaces development config
-│   │       └── .env                # extends development env vars
+│   │       └── .env.template       # extends development env vars (tracked)
 │   └── artifacts/                  # generated outputs
 │       ├── audit-log/              # deployment snapshots (gitignored)
 │       ├── certificates/           # TLS certificates (gitignored)


### PR DESCRIPTION
This pull request refactors how environment variable files are managed for both development and production environments. Instead of tracking `.env` files directly, the system now uses `.env.template` files (tracked in version control) to define required keys, and creates corresponding `.env` files (gitignored) with actual values as needed. This improves security and developer experience by preventing secrets from being committed and ensuring missing keys are surfaced early. The changes update documentation, initialization logic, and deployment behavior, and add robust tests for the new workflow.

**Environment file management overhaul**

* Introduced `.env.template` files (tracked) for both development and production, and updated documentation and sample project structures to reflect this. `.env` files are now gitignored and auto-created from their templates if missing.

**Deployment and initialization logic**

* Added `EnsureEnvFile` function in `internal/compose/env.go` to copy `.env.template` to `.env` if the latter is missing, or create a default if the template is missing. Integrated this into the deploy command and project initialization to ensure `.env` files are always present but not tracked. 

**Configuration and test updates**

* Added new config helpers (`DevEnvTemplate`, `ProdEnvTemplate`) and updated tests to support and verify the new `.env.template` workflow.