### PR TITLE
fix(git): turn quiet

### DIFF
--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -83,9 +83,10 @@ func runClone(cmd *cobra.Command, args []string) error {
 	}
 
 	logger.L.Info(fmt.Sprintf("Cloning %s into %s ...", url, displayTarget))
-	gitCmd := exec.Command("git", "clone", url, target) // #nosec G204 — URL is user-supplied intentionally
+	gitCmd := exec.Command("git", "clone", "--quiet", url, target) // #nosec G204 — URL is user-supplied intentionally
 	gitCmd.Stdout = os.Stdout
 	gitCmd.Stderr = os.Stderr
+	gitCmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if err := gitCmd.Run(); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}

--- a/internal/cli/initialize.go
+++ b/internal/cli/initialize.go
@@ -126,9 +126,10 @@ func cloneProject(url, target string) error {
 	}
 
 	logger.L.Info(fmt.Sprintf("Cloning %s into %s ...", url, displayTarget))
-	gitCmd := exec.Command("git", "clone", url, target) // #nosec G204 — URL is user-supplied intentionally
+	gitCmd := exec.Command("git", "clone", "--quiet", url, target) // #nosec G204 — URL is user-supplied intentionally
 	gitCmd.Stdout = os.Stdout
 	gitCmd.Stderr = os.Stderr
+	gitCmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if err := gitCmd.Run(); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}


### PR DESCRIPTION
This pull request updates the way the `git clone` command is executed in both the `clone.go` and `initialize.go` CLI workflows. The main improvements are to suppress unnecessary output during cloning and to prevent interactive prompts, making the cloning process quieter and more suitable for automation.

**Improvements to git clone execution:**

* Added the `--quiet` flag to the `git clone` command in both `runClone` and `cloneProject` functions to reduce console output during cloning.
* Set the environment variable `GIT_TERMINAL_PROMPT=0` to disable interactive prompts for credentials, ensuring non-interactive and automated usage works smoothly.