### PR TITLE
feat(update): prompt to self-update on version incompatibility

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,12 @@ import (
 	"github.com/dargstack/dargstack/v4/internal/update"
 	"github.com/dargstack/dargstack/v4/internal/version"
 )
+
+// selfUpdateFunc performs a self-update; overridden in tests.
+var selfUpdateFunc = update.SelfUpdate
+
+// confirmFunc asks the user a yes/no question; overridden in tests.
+var confirmFunc = prompt.Confirm
 
 var (
 	cfgPath       string
@@ -99,7 +106,7 @@ var rootCmd = &cobra.Command{
 
 		cfg, err = config.Load(stackDir)
 		if err != nil {
-			return err
+			return resolveVersionIncompatibility(err)
 		}
 
 		// Set STACK_DOMAIN if not already set — use the domain matching the
@@ -192,6 +199,31 @@ func isSkippedCommand(cmd *cobra.Command) bool {
 		}
 	}
 	return false
+}
+
+// resolveVersionIncompatibility offers to self-update when the CLI version
+// does not satisfy the project's compatibility constraint, then asks the
+// user to re-run the command against the new binary. Returns the original
+// error unchanged when no update was offered or performed (offline mode,
+// non-interactive mode, user declined, or the update itself failed).
+func resolveVersionIncompatibility(err error) error {
+	if offline {
+		return err
+	}
+	var incompatErr *config.IncompatibleVersionError
+	if !errors.As(err, &incompatErr) {
+		return err
+	}
+
+	ok, _ := confirmFunc(fmt.Sprintf("%s Update dargstack now?", incompatErr.Error()), false)
+	if !ok {
+		return err
+	}
+
+	if updErr := selfUpdateFunc(); updErr != nil {
+		return fmt.Errorf("%w (self-update failed: %v)", err, updErr)
+	}
+	return errors.New("dargstack was updated — please re-run the command")
 }
 
 // isProduction returns true if the active --environment is "production".

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2,11 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"log/slog"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/dargstack/dargstack/v4/internal/config"
 	"github.com/dargstack/dargstack/v4/internal/logger"
 )
 
@@ -63,6 +65,90 @@ func TestLoggerRespectsLogLevel(t *testing.T) {
 			}
 			if gotStderr != tt.expectStderr {
 				t.Errorf("stderr: got %v, want %v (buf: %q)", gotStderr, tt.expectStderr, errBuf.String())
+			}
+		})
+	}
+}
+
+func TestResolveVersionIncompatibility(t *testing.T) {
+	incompatErr := &config.IncompatibleVersionError{CLIVersion: "1.0.0", Compatibility: ">=2.0.0 <3.0.0"}
+	otherErr := errors.New("some other error")
+
+	tests := []struct {
+		name             string
+		err              error
+		offline          bool
+		confirmResult    bool
+		selfUpdateErr    error
+		wantUpdateCalled bool
+		wantErrIs        error // expect the returned error to wrap/equal this
+		wantErrMsg       string
+	}{
+		{
+			name:      "non-incompatibility error passes through untouched",
+			err:       otherErr,
+			wantErrIs: otherErr,
+		},
+		{
+			name:      "offline skips prompt and self-update",
+			err:       incompatErr,
+			offline:   true,
+			wantErrIs: incompatErr,
+		},
+		{
+			name:          "user declines the prompt",
+			err:           incompatErr,
+			confirmResult: false,
+			wantErrIs:     incompatErr,
+		},
+		{
+			name:             "user accepts and self-update succeeds",
+			err:              incompatErr,
+			confirmResult:    true,
+			selfUpdateErr:    nil,
+			wantUpdateCalled: true,
+			wantErrMsg:       "please re-run the command",
+		},
+		{
+			name:             "user accepts but self-update fails",
+			err:              incompatErr,
+			confirmResult:    true,
+			selfUpdateErr:    errors.New("network unreachable"),
+			wantUpdateCalled: true,
+			wantErrIs:        incompatErr,
+			wantErrMsg:       "network unreachable",
+		},
+	}
+
+	oldOffline := offline
+	oldConfirm := confirmFunc
+	oldSelfUpdate := selfUpdateFunc
+	defer func() {
+		offline = oldOffline
+		confirmFunc = oldConfirm
+		selfUpdateFunc = oldSelfUpdate
+	}()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			offline = tt.offline
+			confirmFunc = func(string, bool) (bool, error) { return tt.confirmResult, nil }
+			called := false
+			selfUpdateFunc = func() error {
+				called = true
+				return tt.selfUpdateErr
+			}
+
+			got := resolveVersionIncompatibility(tt.err)
+
+			if called != tt.wantUpdateCalled {
+				t.Errorf("selfUpdateFunc called=%v, want %v", called, tt.wantUpdateCalled)
+			}
+			if tt.wantErrIs != nil && !errors.Is(got, tt.wantErrIs) {
+				t.Errorf("expected error to wrap %v, got %v", tt.wantErrIs, got)
+			}
+			if tt.wantErrMsg != "" && (got == nil || !strings.Contains(got.Error(), tt.wantErrMsg)) {
+				t.Errorf("expected error to contain %q, got %v", tt.wantErrMsg, got)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -268,6 +268,21 @@ func (c *Config) applyDefaults() {
 
 var validStackName = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9_.-]*[a-zA-Z0-9])?$`)
 
+// IncompatibleVersionError indicates the running CLI version does not
+// satisfy the project's compatibility constraint. Callers can use
+// errors.As to detect this case and, e.g., offer to self-update.
+type IncompatibleVersionError struct {
+	CLIVersion    string
+	Compatibility string
+}
+
+func (e *IncompatibleVersionError) Error() string {
+	return fmt.Sprintf(
+		"cli version %s does not satisfy project compatibility range %s — please update dargstack",
+		e.CLIVersion, e.Compatibility,
+	)
+}
+
 func (c *Config) validate() error {
 	if !validStackName.MatchString(c.Metadata.Name) {
 		return fmt.Errorf("invalid stack name %q: must be alphanumeric with hyphens/underscores/dots", c.Metadata.Name)
@@ -290,10 +305,7 @@ func (c *Config) validate() error {
 	}
 
 	if !constraint.Check(v) {
-		return fmt.Errorf(
-			"cli version %s does not satisfy project compatibility range %s — please update dargstack",
-			version.Version, c.Metadata.Compatibility,
-		)
+		return &IncompatibleVersionError{CLIVersion: version.Version, Compatibility: c.Metadata.Compatibility}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dargstack/dargstack/v4/internal/version"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -161,6 +164,34 @@ func TestBuildModeInvalid(t *testing.T) {
 	_, err := Load(dir)
 	if err == nil {
 		t.Fatal("expected error for invalid build mode")
+	}
+}
+
+func TestIncompatibleVersion(t *testing.T) {
+	oldVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = oldVersion }()
+
+	dir := t.TempDir()
+	content := "metadata:\n  compatibility: \">=2.0.0 <3.0.0\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ConfigFileName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected incompatible version error")
+	}
+
+	var incompatErr *IncompatibleVersionError
+	if !errors.As(err, &incompatErr) {
+		t.Fatalf("expected *IncompatibleVersionError, got %T: %v", err, err)
+	}
+	if incompatErr.CLIVersion != "1.0.0" {
+		t.Errorf("expected CLIVersion=1.0.0, got %s", incompatErr.CLIVersion)
+	}
+	if incompatErr.Compatibility != ">=2.0.0 <3.0.0" {
+		t.Errorf("expected Compatibility=>=2.0.0 <3.0.0, got %s", incompatErr.Compatibility)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `config.IncompatibleVersionError` so the CLI-version/project-compatibility mismatch is a typed error instead of a plain string.
- When that error occurs, the CLI now offers an interactive y/n prompt to self-update (`Update dargstack now?`) instead of only erroring out, addressing the request in #116.
- `--offline`, `--no-interaction`, declining the prompt, or the update itself failing all fall back to the original error-only behavior.

Closes #116