### PR TITLE
fix(deploy): don't clobber explicit STACK_DOMAIN after tag checkout reload

### DIFF
--- a/internal/cli/deploy_run.go
+++ b/internal/cli/deploy_run.go
@@ -40,9 +40,7 @@ func runDeployWithExecutor(ctx context.Context, _ *cobra.Command, dockerClient *
 		if err != nil {
 			return fmt.Errorf("reload config after tag checkout: %w", err)
 		}
-		// Re-apply STACK_DOMAIN from the reloaded config.
-		stackDomain := cfg.Environment.Production.Domain
-		_ = os.Setenv("STACK_DOMAIN", stackDomain)
+		applyStackDomainDefault()
 	}
 
 	// Ensure .env files exist (copied from .env.template if missing).

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,11 @@ var (
 
 	cfg      *config.Config
 	stackDir string
+
+	// stackDomainExplicit records whether STACK_DOMAIN was set in the
+	// environment before dargstack ran, so applyStackDomainDefault never
+	// overrides a user-supplied value.
+	stackDomainExplicit bool
 )
 
 const (
@@ -104,21 +109,14 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
+		stackDomainExplicit = os.Getenv("STACK_DOMAIN") != ""
+
 		cfg, err = config.Load(stackDir)
 		if err != nil {
 			return resolveVersionIncompatibility(err)
 		}
 
-		// Set STACK_DOMAIN if not already set — use the domain matching the
-		// active --environment. Production commands use the production domain;
-		// development commands use the development domain.
-		if os.Getenv("STACK_DOMAIN") == "" {
-			domain := cfg.Environment.Development.Domain
-			if env == "production" {
-				domain = cfg.Environment.Production.Domain
-			}
-			_ = os.Setenv("STACK_DOMAIN", domain)
-		}
+		applyStackDomainDefault()
 
 		return nil
 	},
@@ -126,6 +124,24 @@ var rootCmd = &cobra.Command{
 		result := update.CollectBackgroundCheck()
 		update.PrintUpdateNotice(result)
 	},
+}
+
+// applyStackDomainDefault sets STACK_DOMAIN from cfg unless the user
+// explicitly set it in the environment. It uses the domain matching the
+// active --environment: production commands use the production domain,
+// development commands use the development domain. Called once from
+// PersistentPreRunE, and again by production deploy after checkoutDeployTag
+// reloads cfg, so the env var reflects whichever dargstack.yaml is actually
+// on disk.
+func applyStackDomainDefault() {
+	if stackDomainExplicit {
+		return
+	}
+	domain := cfg.Environment.Development.Domain
+	if env == "production" {
+		domain = cfg.Environment.Production.Domain
+	}
+	_ = os.Setenv("STACK_DOMAIN", domain)
 }
 
 func init() {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -154,6 +154,67 @@ func TestResolveVersionIncompatibility(t *testing.T) {
 	}
 }
 
+func TestApplyStackDomainDefault(t *testing.T) {
+	tests := []struct {
+		name                string
+		env                 string
+		stackDomainExplicit bool
+		wantDomain          string
+	}{
+		{
+			name:       "development uses development domain",
+			env:        "development",
+			wantDomain: "dev.example.com",
+		},
+		{
+			name:       "production uses production domain",
+			env:        "production",
+			wantDomain: "prod.example.com",
+		},
+		{
+			name:                "explicit STACK_DOMAIN is preserved",
+			env:                 "production",
+			stackDomainExplicit: true,
+			wantDomain:          "user-provided.example.com",
+		},
+	}
+
+	oldCfg := cfg
+	oldEnv := env
+	oldStackDomainExplicit := stackDomainExplicit
+	defer func() {
+		cfg = oldCfg
+		env = oldEnv
+		stackDomainExplicit = oldStackDomainExplicit
+	}()
+
+	cfg = &config.Config{
+		Environment: config.EnvironmentConfig{
+			Development: config.DevConfig{Domain: "dev.example.com"},
+			Production:  config.ProdConfig{Domain: "prod.example.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env = tt.env
+			stackDomainExplicit = tt.stackDomainExplicit
+			if tt.stackDomainExplicit {
+				t.Setenv("STACK_DOMAIN", "user-provided.example.com")
+			} else {
+				t.Setenv("STACK_DOMAIN", "")
+				_ = os.Unsetenv("STACK_DOMAIN")
+			}
+
+			applyStackDomainDefault()
+
+			if got := os.Getenv("STACK_DOMAIN"); got != tt.wantDomain {
+				t.Errorf("STACK_DOMAIN: got %q, want %q", got, tt.wantDomain)
+			}
+		})
+	}
+}
+
 func TestResolveProfiles(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
- `main` already reloads `cfg` after checking out the production deploy tag
  (#107), but unconditionally re-sets `STACK_DOMAIN` from it — silently
  overriding a value the user explicitly set, even though the initial
  `PersistentPreRunE` set correctly guards against that.
- Extract `applyStackDomainDefault()` and track `stackDomainExplicit` (captured
  before `config.Load`, since by the time the reload runs `STACK_DOMAIN` is
  always non-empty either way) so the post-reload re-apply respects the same
  guard as the initial set.