### PR TITLE
fix(cli): route ad-hoc status/hint output through lipgloss for consistent, NO_COLOR-aware styling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,14 @@ Pull requests should:
 - Error strings should not be capitalized (per Go conventions).
 - Check all error return values (enforced by `errcheck`).
 
+## Terminal Output & Color
+
+All colored/styled terminal output goes through `internal/logger` (backed by `lipgloss`), never raw ANSI escape codes (`\033[...`). Raw escapes bypass `NO_COLOR` and non-TTY detection, which lipgloss handles automatically.
+
+- **Semantic status** (error/warning/info/success) — use `logger.L.Error/Warn/Info/Debug` for structured log messages, or `logger.Style{Err,Warn,Info,OK}.Render(...)` / `logger.Success(...)` for one-off lines printed outside the logger (e.g. `fmt.Fprintln(os.Stderr, logger.StyleWarn.Render(...))`). Pick the style by meaning: `StyleErr` for failures, `StyleWarn` for things needing attention, `StyleInfo` for "nothing to do" / general info, `StyleOK`/`Success` for a completed action.
+- **Non-semantic coloring** (e.g. distinguishing concurrent output streams by identity rather than severity) should still render through `lipgloss.NewStyle().Foreground(lipgloss.Color(...))` rather than hand-rolled escape sequences, so it still degrades correctly under `NO_COLOR`/non-TTY.
+- **Leave plain**: tabular/report output (e.g. `secret list`, `audit` reports), raw passthrough of external tool/process output, and anything piped for machine consumption. Don't colorize these — it would break alignment and scriptability.
+
 ## Testing
 
 - Tests live alongside source files as `*_test.go`.

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -75,7 +75,7 @@ func runSkillInstall(_ *cobra.Command, _ []string) error {
 		if !filepath.IsAbs(skillDir) {
 			displayDir = "./" + skillDir
 		}
-		fmt.Printf("Skill already installed at %s (user-modified)\n", displayDir)
+		fmt.Println(logger.StyleInfo.Render(fmt.Sprintf("Skill already installed at %s (user-modified)", displayDir)))
 		return nil
 	}
 
@@ -92,7 +92,7 @@ func runSkillInstall(_ *cobra.Command, _ []string) error {
 	if !filepath.IsAbs(skillDir) {
 		displayDir = "./" + skillDir
 	}
-	fmt.Printf("Skill already installed at %s (up to date)\n", displayDir)
+	fmt.Println(logger.StyleInfo.Render(fmt.Sprintf("Skill already installed at %s (up to date)", displayDir)))
 	return nil
 }
 
@@ -124,7 +124,7 @@ func runSkillUpdate(_ *cobra.Command, _ []string) error {
 	if updated {
 		logger.Success("Skill updated")
 	} else {
-		fmt.Println("Skill is already up to date")
+		fmt.Println(logger.StyleInfo.Render("Skill is already up to date"))
 	}
 	return nil
 }

--- a/internal/docker/exec.go
+++ b/internal/docker/exec.go
@@ -8,36 +8,42 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/dargstack/dargstack/v4/internal/logger"
 )
 
-// ANSI color codes for build labels. Indexed by hash(label) % len.
-var buildColors = []string{
-	"\033[38;5;81m",  // blue
-	"\033[38;5;118m", // green
-	"\033[38;5;209m", // yellow
-	"\033[38;5;219m", // cyan
-	"\033[38;5;161m", // magenta
-	"\033[38;5;166m", // red
-	"\033[38;5;72m",  // teal
-	"\033[38;5;203m", // orange
+// buildLabelColors are ANSI 256-color codes used to distinguish concurrent
+// build streams by label identity (not severity). Indexed by hash(label) % len.
+// Rendered through lipgloss so NO_COLOR / non-TTY output degrades automatically,
+// same as the severity styles in internal/logger.
+var buildLabelColors = []string{
+	"81",  // blue
+	"118", // green
+	"209", // yellow
+	"219", // cyan
+	"161", // magenta
+	"166", // red
+	"72",  // teal
+	"203", // orange
 }
-
-const resetColor = "\033[0m"
 
 // labelWriter wraps an io.Writer, prepending a color-coded "[label] " prefix
 // to each line. Safe for concurrent use.
 type labelWriter struct {
 	mu     sync.Mutex
 	w      io.Writer
-	prefix string // includes color codes, e.g. "\033[38;5;81m[api]\033[0m "
+	prefix string // pre-rendered "[label] " including color codes
 }
 
 func newLabelWriter(w io.Writer, label string) *labelWriter {
 	h := hashString(label)
-	color := buildColors[h%uint32(len(buildColors))]
+	code := buildLabelColors[h%uint32(len(buildLabelColors))]
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(code))
 	return &labelWriter{
 		w:      w,
-		prefix: color + "[" + label + "]" + resetColor + " ",
+		prefix: style.Render("["+label+"]") + " ",
 	}
 }
 
@@ -130,7 +136,7 @@ func needsSudo(binary string) bool {
 		}
 		// Credentials may have expired. Fall back to interactive sudo so the
 		// user can authenticate once rather than getting a silent permission error.
-		fmt.Fprintln(os.Stderr, "sudo: Docker requires elevated privileges on this system. Please authenticate to continue.")
+		fmt.Fprintln(os.Stderr, logger.StyleWarn.Render("sudo: Docker requires elevated privileges on this system. Please authenticate to continue."))
 		sudoI := exec.Command("sudo", binary, "info")
 		sudoI.Stdin = os.Stdin
 		sudoI.Stdout = nil
@@ -153,7 +159,7 @@ func prewarmSudo() error {
 		return nil
 	}
 	// Credentials not cached — a password prompt is about to appear.
-	fmt.Fprintln(os.Stderr, "sudo: Docker requires elevated privileges on this system. Please authenticate to continue.")
+	fmt.Fprintln(os.Stderr, logger.StyleWarn.Render("sudo: Docker requires elevated privileges on this system. Please authenticate to continue."))
 	cmd := exec.Command("sudo", "-v")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -42,15 +42,15 @@ func EnsureCertificates(certDir string, domains []string) error {
 		if !needsRegen {
 			return nil
 		}
-		fmt.Printf("Regenerating TLS certificate: %s\n", reason)
+		fmt.Println(logger.StyleInfo.Render(fmt.Sprintf("Regenerating TLS certificate: %s", reason)))
 	}
 
 	if hasMkcert() {
 		return generateWithMkcert(certDir, domains)
 	}
 
-	fmt.Println("mkcert not found - generating self-signed certificate")
-	fmt.Println("  Install mkcert for browser-trusted local certificates: https://github.com/FiloSottile/mkcert")
+	fmt.Println(logger.StyleInfo.Render("mkcert not found - generating self-signed certificate"))
+	fmt.Println(logger.StyleInfo.Render("  Install mkcert for browser-trusted local certificates: https://github.com/FiloSottile/mkcert"))
 	return generateSelfSigned(certFile, keyFile, domains)
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -141,7 +141,7 @@ func SelfUpdate() error {
 	}
 
 	if !latest.GreaterThan(current.String()) {
-		fmt.Printf("Already at latest version %s\n", currentVersion())
+		fmt.Println(logger.StyleInfo.Render(fmt.Sprintf("Already at latest version %s", currentVersion())))
 		return nil
 	}
 
@@ -157,7 +157,7 @@ func SelfUpdate() error {
 		return fmt.Errorf("update: %w", err)
 	}
 
-	fmt.Printf("Updated to %s\n", latest.Version())
+	logger.Success(fmt.Sprintf("Updated to %s", latest.Version()))
 	return nil
 }
 


### PR DESCRIPTION
- Colors the docker-sudo authentication hints (previously plain text) using the existing `logger.StyleWarn`, matching how other CLI hints/warnings are styled elsewhere.
- Colors a handful of other one-off status lines (mkcert messages in `tls.go`, already-installed/up-to-date messages in `skill.go` and `update.go`) via `logger.StyleInfo`/`logger.Success`, so "nothing to do" (blue) and "action taken" (green) read consistently across commands.
- Migrates the concurrent build-label color palette in `docker/exec.go` from hand-rolled ANSI 256-color escapes to `lipgloss.NewStyle().Foreground(...)`, so it now respects `NO_COLOR` and non-TTY output like the rest of the app instead of always emitting raw escape codes.